### PR TITLE
PHPBB2: Fixed mapping for ConversationMessage

### DIFF
--- a/class.phpbb2.php
+++ b/class.phpbb2.php
@@ -239,7 +239,7 @@ join z_pmgroup g
       // Coversation Messages.
       $ConversationMessage_Map = array(
           'privmsgs_id' => 'MessageID',
-          'group_id' => 'ConversationID',
+          'groupid' => 'ConversationID',
           'privmsgs_text' => array('Column' => 'Body', 'Filter'=>array($this, 'RemoveBBCodeUIDs')),
           'privmsgs_from_userid' => 'InsertUserID'
       );


### PR DESCRIPTION
ConversationId was mapped to group_id, but group_id doesn't exist in the source table, it's groupid instead. In the effect after the import there is no connection between conversations and messages (user see list of conversations but they are all empty), this fixes that.
