### PR TITLE
Update for vBulletin 5.1 password hashing

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@
  * @package VanillaPorter
  */
 define('APPLICATION', 'Porter');
-define('APPLICATION_VERSION', '2.0.3');
+define('APPLICATION_VERSION', '2.0.4');
 
 if(TRUE || defined('DEBUG'))
    error_reporting(E_ALL);


### PR DESCRIPTION
- vB5: Remove `password` and `salt` as required columns
- vB5: Detect & convert new password hashing in vB 5.1.
