### PR TITLE
Adds 'destpath' param

### DIFF
--- a/class.exportcontroller.php
+++ b/class.exportcontroller.php
@@ -79,10 +79,14 @@ abstract class ExportController {
             $Msg = $this->Ex->Comments;
 
             // Write the results.
-            if($this->Ex->UseStreaming)
+            if($this->Ex->UseStreaming) {
                exit;
-            else
-               ViewExportResult($Msg, 'Info', $this->Ex->Path);
+            }
+            else {
+               // Send no path if we don't know where it went.
+               $RelativePath = ($this->Param('destpath', FALSE)) ? FALSE : $this->Ex->Path;
+               ViewExportResult($Msg, 'Info', $RelativePath);
+            }
          }
          else
             ViewForm(array('Supported' => $Supported, 'Msg' => $Msg, 'Info' => $this->DbInfo)); // Back to form with error

--- a/functions/commandline-functions.php
+++ b/functions/commandline-functions.php
@@ -1,15 +1,17 @@
 <?php
 
 $GlobalOptions = array(
+   // Used shortcodes: t, n, u, p, h, x, a, c, f, d, o
    'type'      => array('Type of forum we\'re freeing you from.', 'Req' => TRUE, 'Sx' => ':', 'Field' => 'type', 'Short' => 't'),
    'dbname'    => array('Database name.', 'Req' => TRUE, 'Sx' => ':', 'Field' => 'dbname', 'Short' => 'n'),
    'user'      => array('Database connection username.', 'Req' => TRUE, 'Sx' => ':', 'Field' => 'dbuser', 'Short' => 'u'),
    'password'  => array('Database connection password.', 'Sx' => '::', 'Field' => 'dbpass', 'Short' => 'p', 'Default' => ''),
-   'host'      => array('IP address or hostname to connect to. Default is 127.0.0.1.', 'Sx' => ':', 'Field' => 'dbhost', 'Short' => 'h', 'Default' => '127.0.0.1'),
+   'host'      => array('IP address or hostname to connect to. Default is 127.0.0.1.', 'Sx' => ':', 'Field' => 'dbhost', 'Short' => 'o', 'Default' => '127.0.0.1'),
    'prefix'    => array('The table prefix in the database.', 'Field' => 'prefix', 'Sx' => ':', 'Default' => '', 'Short' => 'x'),
    'avatars'   => array('Enables exporting avatars from the database if supported.', 'Sx' => '::', 'Field' => 'avatars', 'Short' => 'a', 'Default' => ''),
    'cdn'       => array('Prefix to be applied to file paths.', 'Field' => 'cdn', 'Sx' => ':', 'Short' => 'c', 'Default' => ''),
    'files'     => array('Enables exporting attachments from database if supported.', 'Sx' => '::', 'Short' => 'f', 'Default' => ''),
+   'destpath'  => array('Define destination path for the export file.', 'Sx' => '::', 'Short' => 'd', 'Default' => ''),
    'help'      => array('Show this help, duh.', 'Short' => 'h')
 );
 

--- a/functions/render-functions.php
+++ b/functions/render-functions.php
@@ -148,19 +148,25 @@ function ViewForm($Data) {
 
 /**
  * Message: Result of export.
+ *
+ * @param array $Msgs Comments / logs from the export.
+ * @param string $Class CSS class for wrapper.
+ * @param string|bool $Path Path to file for download, or false.
  */
-function ViewExportResult($Msgs = '', $Class = 'Info', $Path = '') {
+function ViewExportResult($Msgs = array(), $Class = 'Info', $Path = FALSE) {
    if (defined('CONSOLE')) {
       return;
    }
    
    PageHeader();
 
+   echo "<p class=\"DownloadLink\">Success!";
    if ($Path) {
-      echo "<p class=\"DownloadLink\">Success! <a href=\"$Path\"><b>Download exported file</b></a></p>";
+      " <a href=\"$Path\"><b>Download exported file</b></a>";
    }
+   echo "</p>";
 
-   if ($Msgs) {
+   if (count($Msgs)) {
       echo "<div class=\"$Class\">";
        echo "<p>Really boring export logs follow:</p>\n";
       foreach($Msgs as $Msg) {


### PR DESCRIPTION
- Add `destpath` to define where to send the output file.
- Refactor and cleanup `BeginExport()`.
- Cleanup results UI; only show link if no `destpath` was sent.
- Fix overlapping shortcode for `--host`
