### PR TITLE
Improve charset handling & fix vBulletin category name decoding

### DIFF
--- a/class.exportmodel.php
+++ b/class.exportmodel.php
@@ -721,6 +721,9 @@ class ExportModel {
          return FALSE;
       if ($CollationRow = mysql_fetch_assoc($Data)) {
          $CharacterSet = $CollationRow['Charset'];
+         if (!defined('PORTER_CHARACTER_SET')) {
+            define('PORTER_CHARACTER_SET', $CharacterSet);
+         }
          return $CharacterSet;
       }
       return FALSE;

--- a/functions/filter-functions.php
+++ b/functions/filter-functions.php
@@ -39,7 +39,8 @@ function ForceIP4($ip) {
  * Decode the HTML out of a value.
  */
 function HTMLDecoder($Value) {
-   return html_entity_decode($Value, ENT_QUOTES, 'UTF-8');
+   $CharacterSet =  (defined(PORTER_CHARACTER_SET)) ? PORTER_CHARACTER_SET : 'UTF-8';
+   return html_entity_decode($Value, ENT_QUOTES, $CharacterSet);
 }
 
 /**

--- a/functions/structure-functions.php
+++ b/functions/structure-functions.php
@@ -240,6 +240,14 @@ function VanillaStructure() {
             'UserID' => 'int',
             'RoleID' => 'int'
             ),
+      'UserTag' => array(
+            'RecordType' => 'varchar(255)',
+            'RecordID' => 'int',
+            'TypeID' => 'int',
+            'UserID' => 'int',
+            'DateInserted' => 'datetime',
+            'Total' => 'int'
+            ),
       'Ban' => array(
             'BanID' => 'int',
             'BanType' => 'varchar(50)',

--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@
  * @package VanillaPorter
  */
 define('APPLICATION', 'Porter');
-define('APPLICATION_VERSION', '2.1.3');
+define('APPLICATION_VERSION', '2.1.4');
 
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);
 ini_set('display_errors', 'on');

--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -251,6 +251,9 @@ class Vbulletin extends ExportController {
             if($Row['membergroupids']!='') {
                $Groups = explode(',',$Row['membergroupids']);
                foreach($Groups as $GroupID) {
+                  if (!$GroupID) {
+                     continue;
+                  }
                   $Ex->Query("insert into VbulletinRoles (userid, usergroupid) values({$Row['userid']},{$GroupID})", TRUE);
                }
             }

--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -146,8 +146,9 @@ class Vbulletin extends ExportController {
       
       // Determine the character set
       $CharacterSet = $Ex->GetCharacterSet('post');
-      if ($CharacterSet)
+      if ($CharacterSet) {
          $Ex->CharacterSet = $CharacterSet;
+      }
       
       // Begin
       $Ex->BeginExport('', 'vBulletin 3.* and 4.*');
@@ -343,11 +344,11 @@ class Vbulletin extends ExportController {
       $Category_Map = array(
          'forumid' => 'CategoryID',
          'description' => 'Description',
-         'Name' => array('Column' => 'Name','Filter' => 'HTMLDecoder'),
+         'Name2' => array('Column' => 'Name','Filter' => 'HTMLDecoder'),
          'displayorder' => array('Column' => 'Sort', 'Type' => 'int'),
          'parentid' => 'ParentCategoryID'
       );
-      $Ex->ExportTable('Category', "select f.*, title as Name
+      $Ex->ExportTable('Category', "select f.*, title as Name2
          from :_forum f
          where 1 = 1 $ForumWhere", $Category_Map);
       

--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -285,7 +285,7 @@ class Vbulletin extends ExportController {
          $ProfileQueries = array();
          while ($Field = @mysql_fetch_assoc($ProfileFields)) {
             $Column = str_replace('_title', '', $Field['varname']);
-            $Name = preg_replace('/[^a-zA-Z0-9_-\s]/', '', $Field['text']);
+            $Name = preg_replace('/[^a-zA-Z0-9\s_-]/', '', $Field['text']);
             $ProfileQueries[] = "insert into VbulletinUserMeta (UserID, Name, Value)
                select userid, 'Profile.".$Name."', ".$Column." from :_userfield where ".$Column." != ''";
          }


### PR DESCRIPTION
* Use the correct charset in html_entity_decode
* Force the filter mapping to be used in vBulletin by preventing the `select as` alias from matching