### PR TITLE
HTML decode charset fix

### DIFF
--- a/functions/filter-functions.php
+++ b/functions/filter-functions.php
@@ -77,6 +77,8 @@ function HTMLDecoder($Value) {
     switch ($CharacterSet) {
         case 'latin1':
             $CharacterSet = 'ISO-8859-1'; break;
+        case 'latin9':
+            $CharacterSet = 'ISO-8859-15'; break;
         case 'utf8':
             $CharacterSet = 'UTF-8'; break;
     }

--- a/functions/filter-functions.php
+++ b/functions/filter-functions.php
@@ -73,6 +73,14 @@ function FormatUrl($Str) {
  */
 function HTMLDecoder($Value) {
    $CharacterSet =  (defined('PORTER_CHARACTER_SET')) ? PORTER_CHARACTER_SET : 'UTF-8';
+
+    switch ($CharacterSet) {
+        case 'latin1':
+            $CharacterSet = 'ISO-8859-1'; break;
+        case 'utf8':
+            $CharacterSet = 'UTF-8'; break;
+    }
+
    return html_entity_decode($Value, ENT_QUOTES, $CharacterSet);
 }
 

--- a/functions/filter-functions.php
+++ b/functions/filter-functions.php
@@ -76,11 +76,14 @@ function HTMLDecoder($Value) {
 
     switch ($CharacterSet) {
         case 'latin1':
-            $CharacterSet = 'ISO-8859-1'; break;
+            $CharacterSet = 'ISO-8859-1';
+            break;
         case 'latin9':
-            $CharacterSet = 'ISO-8859-15'; break;
+            $CharacterSet = 'ISO-8859-15';
+            break;
         case 'utf8':
-            $CharacterSet = 'UTF-8'; break;
+            $CharacterSet = 'UTF-8';
+            break;
     }
 
    return html_entity_decode($Value, ENT_QUOTES, $CharacterSet);


### PR DESCRIPTION
MySQL character set names don't always match up with those recognized by html_entity_decode.  I added a small switch/case for translating the most common.

Supported charset names and aliases for html_entity_decode can be found here: http://php.net/html_entity_decode