### PR TITLE
Updating error message reporting for package and MySQL; Fixes #53

### DIFF
--- a/class.exportcontroller.php
+++ b/class.exportcontroller.php
@@ -137,8 +137,7 @@ abstract class ExportController {
         // Connection
         if (!function_exists('mysql_connect')) {
             $Result = 'mysql_connect is an undefined function.  Verify MySQL extension is installed and enabled.';
-        }
-        elseif ($C = @mysql_connect($this->DbInfo['dbhost'], $this->DbInfo['dbuser'], $this->DbInfo['dbpass'])) {
+        } elseif ($C = @mysql_connect($this->DbInfo['dbhost'], $this->DbInfo['dbuser'], $this->DbInfo['dbpass'])) {
             // Database
             if (mysql_select_db($this->DbInfo['dbname'], $C)) {
                 mysql_close($C);

--- a/class.exportcontroller.php
+++ b/class.exportcontroller.php
@@ -135,7 +135,10 @@ abstract class ExportController {
      */
     public function TestDatabase() {
         // Connection
-        if ($C = @mysql_connect($this->DbInfo['dbhost'], $this->DbInfo['dbuser'], $this->DbInfo['dbpass'])) {
+        if (!function_exists('mysql_connect')) {
+            $Result = 'mysql_connect is an undefined function.  Verify MySQL extension is installed and enabled.';
+        }
+        elseif ($C = @mysql_connect($this->DbInfo['dbhost'], $this->DbInfo['dbuser'], $this->DbInfo['dbpass'])) {
             // Database
             if (mysql_select_db($this->DbInfo['dbname'], $C)) {
                 mysql_close($C);

--- a/index.php
+++ b/index.php
@@ -74,15 +74,19 @@ if (isset($_REQUEST['features'])) {
     } else {
         ViewFeatureTable($Set);
     }
-} elseif (isset($_POST['type']) && array_key_exists($_POST['type'], $Supported)) {
-    // Mini-Factory for conducting exports.
-    $class = ucwords($_POST['type']);
-    $Controller = new $class();
-    if (!method_exists($Controller, $Method)) {
-        echo "This datasource type does not support {$Method}.\n";
-        exit();
+} elseif (isset($_POST['type'])) {
+    if (array_key_exists($_POST['type'], $Supported)) {
+        // Mini-Factory for conducting exports.
+        $class = ucwords($_POST['type']);
+        $Controller = new $class();
+        if (!method_exists($Controller, $Method)) {
+            echo "This datasource type does not support {$Method}.\n";
+            exit();
+        }
+        $Controller->$Method();
+    } else {
+        echo 'Invalid type specified: ' . $_POST['type'];
     }
-    $Controller->$Method();
 } else {
     // Show the web UI to start an export.
     $CanWrite = TestWrite();


### PR DESCRIPTION
Adds error messages (and avoid fatals) for invalid package specification or when attempting to run in an environment without the MySQL extension installed or enabled