### PR TITLE
Adding ability to selective export tables

### DIFF
--- a/class.exportcontroller.php
+++ b/class.exportcontroller.php
@@ -40,6 +40,25 @@ abstract class ExportController {
         $this->Ex->DestDb = $this->Param('destdb', null);
         $this->Ex->TestMode = $this->Param('test', false);
         $this->Ex->UseStreaming = false; //$this->UseStreaming;
+
+        /**
+         * Selective exports
+         * 1. Get the comma-separated list of tables and turn it into an array
+         * 2. Trim off the whitespace
+         * 3. Normalize case to lower
+         * 4. Save to the ExportModel instance
+         */
+        $RestrictedTables = $this->Param('tables', false);
+        if (!empty($RestrictedTables)) {
+            $RestrictedTables = explode(',', $RestrictedTables);
+
+            if (is_array($RestrictedTables) && !empty($RestrictedTables)) {
+                $RestrictedTables = array_map('trim', $RestrictedTables);
+                $RestrictedTables = array_map('strtolower', $RestrictedTables);
+
+                $this->Ex->RestrictedTables = $RestrictedTables;
+            }
+        }
     }
 
     /**

--- a/functions/commandline-functions.php
+++ b/functions/commandline-functions.php
@@ -54,7 +54,13 @@ $GlobalOptions = array(
     ),
     'destpath' => array('Define destination path for the export file.', 'Sx' => '::', 'Short' => 'd', 'Default' => ''),
     'spawn' => array('Create a new package with this name.', 'Sx' => '::', 'Short' => 's', 'Default' => ''),
-    'help' => array('Show this help, duh.', 'Short' => 'h')
+    'help' => array('Show this help, duh.', 'Short' => 'h'),
+    'tables' => array(
+        'Selective export, limited to specified tables, if provided',
+        'Sx' => ':',
+        'Short' => 's',
+        'Default' => ''
+    )
 );
 
 // Go through all of the supported types and add them to the type description.

--- a/functions/render-functions.php
+++ b/functions/render-functions.php
@@ -137,6 +137,13 @@ function ViewForm($Data) {
                     <label>Database Password</label>
                     <input class="InputBox" type="password" name="dbpass" value="<?php echo GetValue('dbpass') ?>"/>
                 </li>
+                <li>
+                    <label>Export Type</label>
+                    <select name="tables" id="ExportTables">
+                        <option value="">All supported data</option>
+                        <option value="User,Role,UserRole,Permission">Only users and roles</option>
+                    </select>
+                </li>
             </ul>
             <div class="Button">
                 <input class="Button" type="submit" value="Begin Export"/>

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -107,6 +107,7 @@ class Phpbb3 extends ExportController {
         $Ex->ExportTable('User', "select *,
             case user_avatar_type
                when 1 then concat('$cdn', 'phpbb/', '$Px', '_', user_id, substr(user_avatar from locate('.', user_avatar)))
+               when 2 then user_avatar
                else null end as photo,
             FROM_UNIXTIME(nullif(user_regdate, 0)) as DateFirstVisit,
             FROM_UNIXTIME(nullif(user_lastvisit, 0)) as DateLastActive,


### PR DESCRIPTION
Add the ability to export specific tables with the "tables" parameter.  If the parameter is passed/not empty, it should contain a comma-separated value of table names.  If ExportModel attempts to export a table that isn't specified in the list (all tables are included by default), the table is skipped.

Should be backwards-compatible with all existing packages.

ExportModel:: ShouldExport can be used in packages to determine if a table should be exported (useful for avoiding unnecessary temporary tables, etc).

Fixes #27