### PR TITLE
Remove references to column StorageMethod

### DIFF
--- a/packages/expressionengine.php
+++ b/packages/expressionengine.php
@@ -199,7 +199,6 @@ class ExpressionEngine extends ExportController {
             concat('imported/', filename) AS Path,
             CASE WHEN post_id > 0 THEN post_id ELSE topic_id END AS ForeignID,
             CASE WHEN post_id > 0 THEN 'comment' ELSE 'discussion' END AS ForeignTable,
-            'local' AS StorageMethod,
             a.*
          FROM forum_forum_attachments a", $Media_Map);
 

--- a/packages/ipb.php
+++ b/packages/ipb.php
@@ -504,7 +504,6 @@ class IPB extends ExportController {
             'attach_filesize' => 'Size',
             'ForeignID' => 'ForeignID',
             'ForeignTable' => 'ForeignTable',
-            'StorageMethod' => 'StorageMethod',
             'img_width' => 'ImageWidth',
             'img_height' => 'ImageHeight'
         );
@@ -515,8 +514,7 @@ class IPB extends ExportController {
    case when p.pid = t.topic_firstpost then 'discussion' else 'comment' end as ForeignTable,
    case when p.pid = t.topic_firstpost then t.tid else p.pid end as ForeignID,
    case a.attach_img_width when 0 then a.attach_thumb_width else a.attach_img_width end as img_width,
-   case a.attach_img_height when 0 then a.attach_thumb_height else a.attach_img_height end as img_height,
-   'local' as StorageMethod
+   case a.attach_img_height when 0 then a.attach_thumb_height else a.attach_img_height end as img_height
 from :_attachments a
 join :_posts p
    on a.attach_rel_id = p.pid and a.attach_rel_module = 'post'

--- a/packages/kunena.php
+++ b/packages/kunena.php
@@ -163,7 +163,6 @@ class Kunena extends ExportController {
          select
             a.*,
             concat(a.folder, '/', a.filename) as path2,
-            'local' as StorageMethod,
             case when m.id = m.thread then 'discussion' else 'comment' end as ForeignTable,
             m.time
          from :_kunena_attachments a

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -466,7 +466,6 @@ join z_pmgroup g
   case when a.post_msg_id = t.topic_first_post_id then a.topic_id else a.post_msg_id end as ForeignID,
   concat('$cdn','FileUpload/', a.physical_filename, '.', a.extension) as Path,
   FROM_UNIXTIME(a.filetime) as DateInserted,
-  'local' as StorageMethod,
   a.*
 from :_attachments a
 join :_topics t

--- a/packages/vanilla1.php
+++ b/packages/vanilla1.php
@@ -493,7 +493,6 @@ join z_pm pm
                 'Name' => 'Name',
                 'MimeType' => 'Type',
                 'Size' => 'Size',
-                //'StorageMethod',
                 'Path' => array('Column' => 'Path', 'Filter' => array($this, 'StripMediaPath')),
                 'UserID' => 'InsertUserID',
                 'DateCreated' => 'DateInserted',
@@ -501,7 +500,7 @@ join z_pm pm
                 //'ForeignTable'
             );
             $Ex->ExportTable('Media',
-                "select a.*, 'local' as StorageMethod, 'comment' as ForeignTable from :_Attachment a",
+                "select a.*, 'comment' as ForeignTable from :_Attachment a",
                 $Media_Map);
         }
 

--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -944,7 +944,6 @@ class Vbulletin extends ExportController {
             case when t.threadid is not null then 'discussion' when ct.class = 'Post' then 'comment' when ct.class = 'Thread' then 'discussion' else ct.class end as ForeignTable,
             case when t.threadid is not null then t.threadid else a.contentid end as ForeignID,
             FROM_UNIXTIME(a.dateline) as DateInserted,
-            'local' as StorageMethod,
             a.*,
             f.extension, f.filesize $AttachColumnsString,
             f.width, f.height, null as filethumb
@@ -966,7 +965,6 @@ class Vbulletin extends ExportController {
             // Lie about the height & width to spoof FileUpload serving generic thumbnail if they aren't set.
             $Extension = ExportModel::FileExtension('a.filename');
             $MediaSql = "select a.attachmentid, a.filename, $Extension as extension $AttachColumnsString, a.userid,
-               'local' as StorageMethod,
                'discussion' as ForeignTable,
                t.threadid as ForeignID,
                FROM_UNIXTIME(a.dateline) as DateInserted,
@@ -980,7 +978,6 @@ class Vbulletin extends ExportController {
             union all
 
             select a.attachmentid, a.filename, $Extension as extension $AttachColumnsString, a.userid,
-               'local' as StorageMethod,
                'comment' as ForeignTable,
                a.postid as ForeignID,
                FROM_UNIXTIME(a.dateline) as DateInserted,

--- a/packages/vbulletin5.php
+++ b/packages/vbulletin5.php
@@ -516,7 +516,6 @@ class Vbulletin5 extends Vbulletin {
                 n.parentid as ForeignID,
                 f.extension,
                 f.filesize,
-                'local' as StorageMethod,
                 if(n2.parentid in (" . implode(',', $CategoryIDs) . "),'discussion','comment') as ForeignTable
             from :_attach a
                 left join :_node n on n.nodeid = a.nodeid


### PR DESCRIPTION
There were references to an old method, StorageMethod, from the Media tables in multiple packages.
In some package it caused some fatal errors so I just removed references to it in all packages.
Also fixes #75