### PR TITLE
Fix a broken query in the phpbb2 package

### DIFF
--- a/packages/phpbb2.php
+++ b/packages/phpbb2.php
@@ -106,9 +106,13 @@ class Phpbb2 extends ExportController {
             'group_id' => 'RoleID'
         );
         // Skip pending memberships
-        $Ex->ExportTable('UserRole', 'select user_id, group_id from :_users
-         union
-         select user_id, group_id from :_user_group where user_pending = 0', $UserRole_Map);
+        $Ex->ExportTable('UserRole', '
+            select
+                user_id,
+                group_id
+            from :_user_group
+            where user_pending = 0
+        ;', $UserRole_Map);
 
         // Categories
         $Category_Map = array(


### PR DESCRIPTION
I fixed a broken query that requested an non-existing column on the user table.
Querying the user_group table should be enough.