### PR TITLE
Fix prefixes and normalize character set determination.

### DIFF
--- a/packages/advancedforum.php
+++ b/packages/advancedforum.php
@@ -35,6 +35,7 @@ class advancedforum extends ExportController {
      * @see $_Structures in ExportModel for allowed destination tables & columns.
      */
     public function ForumExport($Ex) {
+
         $CharacterSet = $Ex->GetCharacterSet('node');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/advancedforum.php
+++ b/packages/advancedforum.php
@@ -35,7 +35,7 @@ class advancedforum extends ExportController {
      * @see $_Structures in ExportModel for allowed destination tables & columns.
      */
     public function ForumExport($Ex) {
-        $CharacterSet = $Ex->GetCharacterSet(':_node');
+        $CharacterSet = $Ex->GetCharacterSet('node');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;
         }

--- a/packages/aspplayground.php
+++ b/packages/aspplayground.php
@@ -20,7 +20,7 @@ class APG extends ExportController {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
-        $CharacterSet = $Ex->GetCharacterSet('pgd_Threads');
+        $CharacterSet = $Ex->GetCharacterSet('Threads');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;
         }

--- a/packages/aspplayground.php
+++ b/packages/aspplayground.php
@@ -20,6 +20,7 @@ class APG extends ExportController {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
+
         $CharacterSet = $Ex->GetCharacterSet('Threads');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/bbpress.php
+++ b/packages/bbpress.php
@@ -158,7 +158,7 @@ class BbPress extends ExportController {
             $Ex->Query("create temporary table bbpmto (UserID int, ConversationID int)");
 
             if ($ConversationVersion == 'new') {
-                $To = $Ex->Query("select object_id, meta_value from bb_meta where object_type = 'bbpm_thread' and meta_key = 'to'",
+                $To = $Ex->Query("select object_id, meta_value from :_meta where object_type = 'bbpm_thread' and meta_key = 'to'",
                     true);
                 if (is_resource($To)) {
                     while (($Row = @mysql_fetch_assoc($To)) !== false) {
@@ -186,7 +186,7 @@ class BbPress extends ExportController {
                  pm_thread,
                  pm_from,
                  del_sender as Deleted
-               from bb_bbpm
+               from :_bbpm
 
                union
 
@@ -194,7 +194,7 @@ class BbPress extends ExportController {
                  pm_thread,
                  pm_to,
                  del_reciever
-               from bb_bbpm', $ConUser_Map);
+               from :_bbpm', $ConUser_Map);
             }
         }
 

--- a/packages/bbpress.php
+++ b/packages/bbpress.php
@@ -33,6 +33,12 @@ class BbPress extends ExportController {
      * @param ExportModel $Ex
      */
     protected function ForumExport($Ex) {
+
+        $CharacterSet = $Ex->GetCharacterSet('posts');
+        if ($CharacterSet) {
+            $Ex->CharacterSet = $CharacterSet;
+        }
+
         // Begin
         $Ex->BeginExport('', 'bbPress 1.*', array('HashMethod' => 'Vanilla'));
 

--- a/packages/drupal.php
+++ b/packages/drupal.php
@@ -28,9 +28,7 @@ class Drupal extends ExportController {
      * @param ExportModel $Ex
      */
     protected function ForumExport($Ex) {
-        $this->Ex = $Ex;
 
-        // Get the characterset for the comments.
         $CharacterSet = $Ex->GetCharacterSet('comment');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/esotalk.php
+++ b/packages/esotalk.php
@@ -27,8 +27,7 @@ class esotalk extends ExportController {
      * @see $_Structures in ExportModel for allowed destination tables & columns.
      */
     public function ForumExport($Ex) {
-        // Get the characterset for the comments.
-        // Usually the comments table is the best target for this.
+
         $CharacterSet = $Ex->GetCharacterSet('post');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/esotalk.php
+++ b/packages/esotalk.php
@@ -29,7 +29,7 @@ class esotalk extends ExportController {
     public function ForumExport($Ex) {
         // Get the characterset for the comments.
         // Usually the comments table is the best target for this.
-        $CharacterSet = $Ex->GetCharacterSet(':_post');
+        $CharacterSet = $Ex->GetCharacterSet('post');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;
         }

--- a/packages/expressionengine.php
+++ b/packages/expressionengine.php
@@ -29,7 +29,7 @@ class ExpressionEngine extends ExportController {
     public function ForumExport($Ex) {
 
         // Get the characterset for the comments.
-        $CharacterSet = $Ex->GetCharacterSet('forum_topics');
+        $CharacterSet = $Ex->GetCharacterSet('topics');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;
         }

--- a/packages/expressionengine.php
+++ b/packages/expressionengine.php
@@ -28,7 +28,6 @@ class ExpressionEngine extends ExportController {
      */
     public function ForumExport($Ex) {
 
-        // Get the characterset for the comments.
         $CharacterSet = $Ex->GetCharacterSet('topics');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/ipb.php
+++ b/packages/ipb.php
@@ -175,7 +175,6 @@ class IPB extends ExportController {
 
         $Ex->SourcePrefix = ':_';
 
-        // Get the characterset for the comments.
         $CharacterSet = $Ex->GetCharacterSet('posts');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/jforum.php
+++ b/packages/jforum.php
@@ -47,8 +47,7 @@ class Jforum extends ExportController {
      * @see $_Structures in ExportModel for allowed destination tables & columns.
      */
     public function ForumExport($Ex) {
-        // Get the characterset for the comments.
-        // Usually the comments table is the best target for this.
+
         $CharacterSet = $Ex->GetCharacterSet('posts_text');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/kunena.php
+++ b/packages/kunena.php
@@ -25,6 +25,12 @@ class Kunena extends ExportController {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
+
+        $CharacterSet = $Ex->GetCharacterSet('mbox');
+        if ($CharacterSet) {
+            $Ex->CharacterSet = $CharacterSet;
+        }
+
         $Ex->DestPrefix = 'jos';
 
         $Ex->BeginExport('', 'Joomla Kunena', array('HashMethod' => 'joomla'));

--- a/packages/mbox.php
+++ b/packages/mbox.php
@@ -42,6 +42,12 @@ class Mbox extends ExportController {
      * @param ExportModel $Ex
      */
     protected function ForumExport($Ex) {
+
+        $CharacterSet = $Ex->GetCharacterSet('mbox');
+        if ($CharacterSet) {
+            $Ex->CharacterSet = $CharacterSet;
+        }
+
         // Begin
         $Ex->BeginExport('', 'Mbox', array());
 

--- a/packages/mybb.php
+++ b/packages/mybb.php
@@ -40,7 +40,7 @@ class MyBB extends ExportController {
      * @see $_Structures in ExportModel for allowed destination tables & columns.
      */
     public function ForumExport($Ex) {
-        // Get the characterset for the comments.
+
         $CharacterSet = $Ex->GetCharacterSet('posts');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/nodebb.php
+++ b/packages/nodebb.php
@@ -31,6 +31,10 @@ class Nodebb extends ExportController {
      */
     protected function ForumExport($Ex) {
 
+        $CharacterSet = $Ex->GetCharacterSet('topic');
+        if ($CharacterSet) {
+            $Ex->CharacterSet = $CharacterSet;
+        }
 
         $Ex->BeginExport('', 'NodeBB 0.*', array('HashMethod' => 'Vanilla'));
 

--- a/packages/phpbb2.php
+++ b/packages/phpbb2.php
@@ -63,7 +63,7 @@ class Phpbb2 extends ExportController {
      * @param ExportModel $Ex
      */
     protected function ForumExport($Ex) {
-        // Get the characterset for the comments.
+
         $CharacterSet = $Ex->GetCharacterSet('posts_text');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -72,9 +72,7 @@ class Phpbb3 extends ExportController {
      * @param ExportModel $Ex
      */
     protected function ForumExport($Ex) {
-        $this->Ex = $Ex;
 
-        // Get the characterset for the comments.
         $CharacterSet = $Ex->GetCharacterSet('posts');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -89,7 +89,7 @@ class Phpbb3 extends ExportController {
         // Users.
 
         // Grab the avatar salt.
-        $Px = $Ex->GetValue("select config_value from phpbb_config where config_name = 'avatar_salt'", '');
+        $Px = $Ex->GetValue("select config_value from :_config where config_name = 'avatar_salt'", '');
         $cdn = $this->Param('cdn', '');
 
         $User_Map = array(
@@ -113,7 +113,7 @@ class Phpbb3 extends ExportController {
             FROM_UNIXTIME(nullif(user_regdate, 0)) as DateInserted,
             ban_userid is not null as Banned
          from :_users
-            left join phpbb_banlist bl ON (ban_userid = user_id)
+            left join :_banlist bl ON (ban_userid = user_id)
          ", $User_Map);  // ":_" will be replace by database prefix
 
         // Roles
@@ -159,7 +159,7 @@ class Phpbb3 extends ExportController {
         );
         $Ex->ExportTable('Rank', "
          select r.*, r.rank_title as title2, 0 as level
-         from phpbb_ranks r
+         from :_ranks r
          order by rank_special, rank_min;", $Rank_Map);
 
         // Permissions.
@@ -171,7 +171,7 @@ class Phpbb3 extends ExportController {
             when group_name like '%Admin%' then 'All'
             else 'View,Garden.SignIn.Allow,Garden.Profiles.Edit,Vanilla.Discussions.Add,Vanilla.Comments.Add'
          end as _Permissions
-         from phpbb_groups");
+         from :_groups");
 
         // UserRoles
         $UserRole_Map = array(
@@ -191,13 +191,13 @@ class Phpbb3 extends ExportController {
         );
         $Ex->ExportTable('UserMeta', "
          select user_id, 'Plugin.Signatures.Sig' as name, user_sig, user_sig_bbcode_uid as bbcode_uid
-         from phpbb_users
+         from :_users
          where length(user_sig) > 1
 
          union
 
          select user_id, 'Plugin.Signatures.Format', 'BBCode', null
-         from phpbb_users
+         from :_users
          where length(user_sig) > 1
          ", $UserMeta_Map);
 
@@ -364,8 +364,8 @@ set pm.groupid = g.groupid;");
             t.*,
             t.topic_id as poll_id,
             1 as anonymous
-         from phpbb_poll_options po
-         join phpbb_topics t
+         from :_poll_options po
+         join :_topics t
             on po.topic_id = t.topic_id", $Poll_Map);
 
         $PollOption_Map = array(
@@ -385,8 +385,8 @@ set pm.groupid = g.groupid;");
             'Html' as format,
             t.topic_time,
             t.topic_poster
-         from phpbb_poll_options po
-         join phpbb_topics t
+         from :_poll_options po
+         join :_topics t
             on po.topic_id = t.topic_id", $PollOption_Map);
 
         $PollVote_Map = array(
@@ -395,7 +395,7 @@ set pm.groupid = g.groupid;");
         );
         $Ex->ExportTable('PollVote', "
          select v.*, v.poll_option_id * 1000000 + v.topic_id as id
-         from phpbb_poll_votes v", $PollVote_Map);
+         from :_poll_votes v", $PollVote_Map);
 
         // Conversations.
         $Conversation_Map = array(

--- a/packages/punbb.php
+++ b/packages/punbb.php
@@ -46,6 +46,11 @@ class Punbb extends ExportController {
      */
     protected function ForumExport($Ex) {
 
+        $CharacterSet = $Ex->GetCharacterSet('posts');
+        if ($CharacterSet) {
+            $Ex->CharacterSet = $CharacterSet;
+        }
+
         $Ex->BeginExport('', 'PunBB 1.*', array('HashMethod' => 'punbb'));
 
         $this->cdn = $this->Param('cdn', '');

--- a/packages/simplepress.php
+++ b/packages/simplepress.php
@@ -37,7 +37,6 @@ class SimplePress extends ExportController {
     protected function ForumExport($Ex) {
         $Ex->SourcePrefix = 'wp_';
 
-        // Get the characterset for the comments.
         $CharacterSet = $Ex->GetCharacterSet('posts');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/simplepress.php
+++ b/packages/simplepress.php
@@ -57,8 +57,8 @@ class SimplePress extends ExportController {
         );
         $Ex->ExportTable('User',
             "select m.*, u.user_pass, u.user_email, u.user_registered
-          from wp_users u
-          join wp_sfmembers m
+          from :_users u
+          join :_sfmembers m
             on u.ID = m.user_id;", $User_Map);
 
         // Roles
@@ -72,7 +72,7 @@ class SimplePress extends ExportController {
             usergroup_id,
             usergroup_name,
             usergroup_desc
-         from wp_sfusergroups
+         from :_sfusergroups
 
          union
 
@@ -89,7 +89,7 @@ case
    when usergroup_name like 'Member%' then 'View,Garden.SignIn.Allow,Garden.Profiles.Edit,Vanilla.Discussions.Add,Vanilla.Comments.Add'
    when usergroup_name like 'Mod%' then 'View,Garden.SignIn.Allow,Garden.Profiles.Edit,Garden.Settings.View,Vanilla.Discussions.Add,Vanilla.Comments.Add,Garden.Moderation.Manage'
 end as _Permissions
-         from wp_sfusergroups
+         from :_sfusergroups
 
          union
 
@@ -104,14 +104,14 @@ end as _Permissions
             "select
             m.user_id,
             m.usergroup_id
-         from wp_sfmemberships m
+         from :_sfmemberships m
 
          union
 
          select
             um.user_id,
             100
-         from wp_usermeta um
+         from :_usermeta um
          where um.meta_key = 'wp_capabilities'
             and um.meta_value like '%PF Manage Forums%'", $UserRole_Map);
 
@@ -132,7 +132,7 @@ end as _Permissions
             f.forum_desc,
             lower(f.forum_slug) as forum_slug,
             case when f.parent = 0 then f.group_id + 1000 else f.parent end as parent_id
-         from wp_sfforums f
+         from :_sfforums f
 
          union
 
@@ -143,7 +143,7 @@ end as _Permissions
             g.group_desc,
             null,
             null
-         from wp_sfgroups g", $Category_Map);
+         from :_sfgroups g", $Category_Map);
 
         // Discussions
         $Discussion_Map = array(

--- a/packages/smf.php
+++ b/packages/smf.php
@@ -40,6 +40,12 @@ class SMF extends ExportController {
      * @param ExportModel $Ex
      */
     protected function ForumExport($Ex) {
+
+        $CharacterSet = $Ex->GetCharacterSet('messages');
+        if ($CharacterSet) {
+            $Ex->CharacterSet = $CharacterSet;
+        }
+
         // Begin
         $Ex->BeginExport('', 'SMF 1.*', array('HashMethod' => 'Django'));
 

--- a/packages/smf2.php
+++ b/packages/smf2.php
@@ -40,6 +40,12 @@ class SMF2 extends ExportController {
      * @param ExportModel $Ex
      */
     protected function ForumExport($Ex) {
+
+        $CharacterSet = $Ex->GetCharacterSet('messages');
+        if ($CharacterSet) {
+            $Ex->CharacterSet = $CharacterSet;
+        }
+
         // Begin
         $Ex->BeginExport('', 'SMF 2.*', array('HashMethod' => 'Django'));
 

--- a/packages/toast.php
+++ b/packages/toast.php
@@ -26,6 +26,7 @@ class Toast extends ExportController {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
+
         $CharacterSet = $Ex->GetCharacterSet('Post');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/toast.php
+++ b/packages/toast.php
@@ -26,7 +26,7 @@ class Toast extends ExportController {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
-        $CharacterSet = $Ex->GetCharacterSet('tstdb_Post');
+        $CharacterSet = $Ex->GetCharacterSet('Post');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;
         }

--- a/packages/uservoice.php
+++ b/packages/uservoice.php
@@ -27,7 +27,7 @@ class UserVoice extends ExportController {
      */
     public function ForumExport($Ex) {
         // Get the characterset for the comments.
-        $CharacterSet = $Ex->GetCharacterSet('cs_Threads');
+        $CharacterSet = $Ex->GetCharacterSet('Threads');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;
         }

--- a/packages/uservoice.php
+++ b/packages/uservoice.php
@@ -26,7 +26,7 @@ class UserVoice extends ExportController {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
-        // Get the characterset for the comments.
+
         $CharacterSet = $Ex->GetCharacterSet('Threads');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/vanilla1.php
+++ b/packages/vanilla1.php
@@ -7,6 +7,7 @@
  * @package VanillaPorter
  */
 
+$Supported['vanilla1'] = array('name' => 'Vanilla 1', 'prefix' => 'LUM_');
 $Supported['vanilla1']['features'] = array(
     'Comments' => 1,
     'Discussions' => 1,

--- a/packages/vanilla1.php
+++ b/packages/vanilla1.php
@@ -61,7 +61,6 @@ class Vanilla1 extends ExportController {
     protected function ForumExport($Ex) {
         $this->Ex = $Ex;
 
-        // Get the characterset for the comments.
         $CharacterSet = $Ex->GetCharacterSet('Comment');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/vanilla2.php
+++ b/packages/vanilla2.php
@@ -7,6 +7,7 @@
  * @package VanillaPorter
  */
 
+$Supported['vanilla2'] = array('name' => 'Vanilla 2', 'prefix' => 'GDN_');
 $Supported['vanilla2']['features'] = array(
     'Comments' => 1,
     'Discussions' => 1,

--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -194,7 +194,6 @@ class Vbulletin extends ExportController {
             $ForumWhere = '';
         }
 
-        // Determine the character set
         $CharacterSet = $Ex->GetCharacterSet('post');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/vbulletin5.php
+++ b/packages/vbulletin5.php
@@ -62,6 +62,7 @@ class Vbulletin5 extends Vbulletin {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
+
         // Determine the character set
         $CharacterSet = $Ex->GetCharacterSet('nodes');
         if ($CharacterSet) {

--- a/packages/vbulletin5.php
+++ b/packages/vbulletin5.php
@@ -63,7 +63,6 @@ class Vbulletin5 extends Vbulletin {
      */
     public function ForumExport($Ex) {
 
-        // Determine the character set
         $CharacterSet = $Ex->GetCharacterSet('nodes');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/webwiz.php
+++ b/packages/webwiz.php
@@ -26,7 +26,7 @@ class WebWiz extends ExportController {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
-        // Get the characterset for the comments.
+
         $CharacterSet = $Ex->GetCharacterSet('Topic');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/webwiz.php
+++ b/packages/webwiz.php
@@ -27,7 +27,7 @@ class WebWiz extends ExportController {
      */
     public function ForumExport($Ex) {
         // Get the characterset for the comments.
-        $CharacterSet = $Ex->GetCharacterSet('tblTopic');
+        $CharacterSet = $Ex->GetCharacterSet('Topic');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;
         }
@@ -93,7 +93,7 @@ class WebWiz extends ExportController {
          case when Avatar like 'http%' then Avatar when Avatar > '' then concat('webwiz/', Avatar) else null end as Photo2,
             'webwiz' as HashMethod,
             u.*
-         from tblAuthor u
+         from :_Author u
          ", $User_Map);
 
 
@@ -104,7 +104,7 @@ class WebWiz extends ExportController {
         );
         $Ex->ExportTable('Role', "
          select *
-         from tblGroup", $Role_Map);
+         from :_Group", $Role_Map);
 
         // User Role.
         $UserRole_Map = array(
@@ -113,7 +113,7 @@ class WebWiz extends ExportController {
         );
         $Ex->ExportTable('UserRole', "
          select u.*
-         from tblAuthor u", $UserRole_Map);
+         from :_Author u", $UserRole_Map);
 
         // UserMeta
         $Ex->ExportTable('UserMeta', "
@@ -121,7 +121,7 @@ class WebWiz extends ExportController {
             Author_ID as UserID,
             'Plugin.Signatures.Sig' as `Name`,
             Signature as `Value`
-         from tblAuthor
+         from :_Author
          where Signature <> ''");
 
         // Category.
@@ -139,7 +139,7 @@ class WebWiz extends ExportController {
             f.Forum_order,
             f.Forum_name,
             f.Forum_description
-         from tblForum f
+         from :_Forum f
 
          union all
 
@@ -149,7 +149,7 @@ class WebWiz extends ExportController {
             c.Cat_order,
             c.Cat_name,
             null
-         from tblCategory c
+         from :_Category c
          ", $Category_Map);
 
         // Discussion.
@@ -174,8 +174,8 @@ class WebWiz extends ExportController {
             th.IP_addr,
             'Html' as Format,
             t.*
-         from tblTopic t
-         join tblThread th
+         from :_Topic t
+         join :_Thread th
             on t.Start_Thread_ID = th.Thread_ID", $Discussion_Map);
 
         // Comment.
@@ -192,8 +192,8 @@ class WebWiz extends ExportController {
       select
          th.*,
          'Html' as Format
-      from tblThread th
-      join tblTopic t
+      from :_Thread th
+      join :_Topic t
          on t.Topic_ID = th.Topic_ID
       where th.Thread_ID <> t.Start_Thread_ID", $Comment_Map);
 
@@ -218,7 +218,7 @@ class WebWiz extends ExportController {
          select
             pm.*,
             g.Title
-         from tblPMMessage pm
+         from :_PMMessage pm
          join z_pmgroup g
             on pm.PM_ID = g.Group_ID;", $Conversation_Map);
 
@@ -249,7 +249,7 @@ class WebWiz extends ExportController {
             pm.*,
             pm2.Group_ID,
             'Html' as Format
-          from tblPMMessage pm
+          from :_PMMessage pm
           join z_pmtext pm2
             on pm.PM_ID = pm2.PM_ID;", $Message_Map);
     }
@@ -271,7 +271,7 @@ class WebWiz extends ExportController {
          select
             PM_ID,
             Author_ID
-         from tblPMMessage;
+         from :_PMMessage;
 
          insert ignore z_pmto (
             PM_ID,
@@ -280,7 +280,7 @@ class WebWiz extends ExportController {
          select
             PM_ID,
             From_ID
-         from tblPMMessage;
+         from :_PMMessage;
 
          drop table if exists z_pmto2;
          create table z_pmto2 (
@@ -317,7 +317,7 @@ class WebWiz extends ExportController {
             PM_ID,
             PM_Tittle,
             case when PM_Tittle like 'Re:%' then trim(substring(PM_Tittle, 4)) else PM_Tittle end as Title2
-         from tblPMMessage;
+         from :_PMMessage;
 
          create index z_idx_pmtext on z_pmtext (PM_ID);
 

--- a/packages/xenforo.php
+++ b/packages/xenforo.php
@@ -146,7 +146,6 @@ class Xenforo extends ExportController {
 
         $Cdn = $this->CdnPrefix();
 
-        // Get the characterset for the comments.
         $CharacterSet = $Ex->GetCharacterSet('posts');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/xenforo.php
+++ b/packages/xenforo.php
@@ -195,8 +195,8 @@ class Xenforo extends ExportController {
             ua.data as password,
             'xenforo' as hash_method,
             case when u.avatar_date > 0 then concat('{$Cdn}xf/', u.user_id div 1000, '/', u.user_id, '.jpg') else null end as avatar
-         from xf_user u
-         left join xf_user_authenticate ua
+         from :_user u
+         left join :_user_authenticate ua
             on u.user_id = ua.user_id", $User_Map);
 
         // Roles.
@@ -206,7 +206,7 @@ class Xenforo extends ExportController {
         );
         $Ex->ExportTable('Role', "
          select *
-         from xf_user_group", $Role_Map);
+         from :_user_group", $Role_Map);
 
         // User Roles.
         $UserRole_Map = array(
@@ -216,13 +216,13 @@ class Xenforo extends ExportController {
 
         $Ex->ExportTable('UserRole', "
          select user_id, user_group_id
-         from xf_user
+         from :_user
 
          union all
 
          select u.user_id, ua.user_group_id
-         from xf_user u
-         join xf_user_group ua
+         from :_user u
+         join :_user_group ua
             on find_in_set(ua.user_group_id, u.secondary_group_ids)", $UserRole_Map);
 
         // Permission.
@@ -247,7 +247,7 @@ class Xenforo extends ExportController {
         );
         $Ex->ExportTable('Category', "
          select n.*
-         from xf_node n
+         from :_node n
          ", $Category_Map);
 
         // Discussions.
@@ -271,10 +271,10 @@ class Xenforo extends ExportController {
             p.message,
             'BBCode' as format,
             ip.ip
-         from xf_thread t
-         join xf_post p
+         from :_thread t
+         join :_post p
             on t.first_post_id = p.post_id
-         left join xf_ip ip
+         left join :_ip ip
             on p.ip_id = ip.ip_id", $Discussion_Map);
 
 
@@ -293,10 +293,10 @@ class Xenforo extends ExportController {
             p.*,
             'BBCode' as format,
             ip.ip
-         from xf_post p
-         join xf_thread t
+         from :_post p
+         join :_thread t
             on p.thread_id = t.thread_id
-         left join xf_ip ip
+         left join :_ip ip
             on p.ip_id = ip.ip_id
          where p.post_id <> t.first_post_id
             and message_state = 'visible'", $Comment_Map);
@@ -310,7 +310,7 @@ class Xenforo extends ExportController {
         );
         $Ex->ExportTable('Conversation', "
          select *
-         from xf_conversation_master", $Conversation_Map);
+         from :_conversation_master", $Conversation_Map);
 
         $ConversationMessage_Map = array(
             'message_id' => 'MessageID',
@@ -326,8 +326,8 @@ class Xenforo extends ExportController {
             m.*,
             'BBCode' as format,
             ip.ip
-         from xf_conversation_message m
-         left join xf_ip ip
+         from :_conversation_message m
+         left join :_ip ip
             on m.ip_id = ip.ip_id", $ConversationMessage_Map);
 
         $UserConversation_Map = array(
@@ -340,7 +340,7 @@ class Xenforo extends ExportController {
             r.conversation_id,
             user_id,
             case when r.recipient_state = 'deleted' then 1 else 0 end as Deleted
-         from xf_conversation_recipient r
+         from :_conversation_recipient r
 
          union all
 
@@ -348,7 +348,7 @@ class Xenforo extends ExportController {
             cu.conversation_id,
             cu.owner_user_id,
             0
-         from xf_conversation_user cu
+         from :_conversation_user cu
          ", $UserConversation_Map);
 
         $Ex->EndExport();
@@ -364,8 +364,8 @@ class Xenforo extends ExportController {
          select
             pe.*,
             g.title
-         from xf_permission_entry pe
-         join xf_user_group g
+         from :_permission_entry pe
+         join :_user_group g
             on pe.user_group_id = g.user_group_id");
         $this->_ExportPermissions($r, $Permissions);
 
@@ -373,8 +373,8 @@ class Xenforo extends ExportController {
           select
             pe.*,
             g.title
-         from xf_permission_entry_content pe
-         join xf_user_group g
+         from :_permission_entry_content pe
+         join :_user_group g
             on pe.user_group_id = g.user_group_id");
         $this->_ExportPermissions($r, $Permissions);
 
@@ -416,7 +416,7 @@ class Xenforo extends ExportController {
            user_id as UserID,
            'Plugin.Signatures.Sig' as Name,
            signature as Value
-         from xf_user_profile
+         from :_user_profile
          where nullif(signature, '') is not null
 
          union
@@ -425,7 +425,7 @@ class Xenforo extends ExportController {
            user_id,
            'Plugin.Signatures.Format',
            'BBCode'
-         from xf_user_profile
+         from :_user_profile
          where nullif(signature, '') is not null";
 
         $Ex->ExportTable('UserMeta', $Sql);

--- a/packages/yaf.php
+++ b/packages/yaf.php
@@ -28,6 +28,7 @@ class Yaf extends ExportController {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
+
         $CharacterSet = $Ex->GetCharacterSet('Topic');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;

--- a/packages/yaf.php
+++ b/packages/yaf.php
@@ -28,7 +28,7 @@ class Yaf extends ExportController {
      * @param ExportModel $Ex
      */
     public function ForumExport($Ex) {
-        $CharacterSet = $Ex->GetCharacterSet('yaf_Topic');
+        $CharacterSet = $Ex->GetCharacterSet('Topic');
         if ($CharacterSet) {
             $Ex->CharacterSet = $CharacterSet;
         }
@@ -59,8 +59,8 @@ class Yaf extends ExportController {
             m.PasswordFormat,
             m.LastActivity,
             'yaf' as HashMethod
-         from yaf_User u
-         left join yaf_prov_Membership m
+         from :_User u
+         left join :_prov_Membership m
             on u.ProviderUserKey = m.UserID;", $User_Map);
 
         // Role.
@@ -70,14 +70,14 @@ class Yaf extends ExportController {
         );
         $Ex->ExportTable('Role', "
          select *
-         from yaf_Group;", $Role_Map);
+         from :_Group;", $Role_Map);
 
         // UserRole.
         $UserRole_Map = array(
             'UserID' => 'UserID',
             'GroupID' => 'RoleID'
         );
-        $Ex->ExportTable('UserRole', 'select * from yaf_UserGroup', $UserRole_Map);
+        $Ex->ExportTable('UserRole', 'select * from :_UserGroup', $UserRole_Map);
 
         // Rank.
         $Rank_Map = array(
@@ -91,7 +91,7 @@ class Yaf extends ExportController {
             r.*,
             RankID as Level,
             Name as Label
-         from yaf_Rank r;", $Rank_Map);
+         from :_Rank r;", $Rank_Map);
 
         // Signatures.
         $Ex->ExportTable('UserMeta', "
@@ -99,7 +99,7 @@ class Yaf extends ExportController {
             UserID,
             'Plugin.Signatures.Sig' as `Name`,
             Signature as `Value`
-         from yaf_User
+         from :_User
          where Signature <> ''
 
          union all
@@ -108,7 +108,7 @@ class Yaf extends ExportController {
             UserID,
             'Plugin.Signatures.Format' as `Name`,
             'BBCode' as `Value`
-         from yaf_User
+         from :_User
          where Signature <> '';");
 
         // Category.
@@ -127,7 +127,7 @@ class Yaf extends ExportController {
             f.Name,
             f.Description,
             f.SortOrder
-         from yaf_Forum f
+         from :_Forum f
 
          union all
 
@@ -137,7 +137,7 @@ class Yaf extends ExportController {
             c.Name,
             null,
             c.SortOrder
-         from yaf_Category c;", $Category_Map);
+         from :_Category c;", $Category_Map);
 
         // Discussion.
         $Discussion_Map = array(
@@ -154,7 +154,7 @@ class Yaf extends ExportController {
             case when t.Priority > 0 then 1 else 0 end as Announce,
             t.Flags & 1 as Closed,
             t.*
-         from yaf_Topic t
+         from :_Topic t
          where t.IsDeleted = 0;", $Discussion_Map);
 
         // Comment.
@@ -174,7 +174,7 @@ class Yaf extends ExportController {
          select
             case when m.Flags & 1 = 1 then 'Html' else 'BBCode' end as Format,
             m.*
-         from yaf_Message m
+         from :_Message m
          where IsDeleted = 0;", $Comment_Map);
 
         // Conversation.
@@ -191,7 +191,7 @@ class Yaf extends ExportController {
             pm.*,
             g.Title
          from z_pmgroup g
-         join yaf_PMessage pm
+         join :_PMessage pm
             on g.Group_ID = pm.PMessageID;", $Conversation_Map);
 
         // UserConversation.
@@ -220,7 +220,7 @@ class Yaf extends ExportController {
             pm.*,
             case when pm.Flags & 1 = 1 then 'Html' else 'BBCode' end as Format,
             t.Group_ID
-         from yaf_PMessage pm
+         from :_PMessage pm
          join z_pmtext t
             on t.PM_ID = pm.PMessageID;", $ConversationMessage_Map);
 
@@ -272,7 +272,7 @@ class Yaf extends ExportController {
             PMessageID,
             FromUserID,
             0
-         from yaf_PMessage;
+         from :_PMessage;
 
          replace z_pmto (
             PM_ID,
@@ -283,7 +283,7 @@ class Yaf extends ExportController {
             PMessageID,
             UserID,
             IsDeleted
-         from yaf_UserPMessage;
+         from :_UserPMessage;
 
          drop table if exists z_pmto2;
          create table z_pmto2 (
@@ -320,7 +320,7 @@ class Yaf extends ExportController {
             PMessageID,
             Subject,
             case when Subject like 'Re:%' then trim(substring(Subject, 4)) else Subject end as Title2
-         from yaf_PMessage;
+         from :_PMessage;
 
          create index z_idx_pmtext on z_pmtext (PM_ID);
 


### PR DESCRIPTION
Some packages used hardcoded prefixes on table instead of using ":_" which allows to use any prefixes.
This PR fixes that.

BONUS: Now all package do character set detection as suggested in tpl_package.txt