### PR TITLE
Use default prefix when none is supplied

### DIFF
--- a/class.exportcontroller.php
+++ b/class.exportcontroller.php
@@ -131,7 +131,7 @@ abstract class ExportController {
             'dbpass' => $_POST['dbpass'],
             'dbname' => $_POST['dbname'],
             'type' => $_POST['type'],
-            'prefix' => !empty($_POST['prefix']) ? preg_replace('/[^A-Za-z0-9_-]/', '', $_POST['prefix']) : null,
+            'prefix' => isset($_POST['prefix']) ? preg_replace('/[^A-Za-z0-9_-]/', '', $_POST['prefix']) : null,
         );
     }
 

--- a/class.exportcontroller.php
+++ b/class.exportcontroller.php
@@ -32,14 +32,21 @@ abstract class ExportController {
 
         $this->Ex = new ExportModel;
         $this->Ex->Controller = $this;
-        $this->Ex->SetConnection($this->DbInfo['dbhost'], $this->DbInfo['dbuser'], $this->DbInfo['dbpass'],
-            $this->DbInfo['dbname']);
+        $this->Ex->SetConnection(
+            $this->DbInfo['dbhost'],
+            $this->DbInfo['dbuser'],
+            $this->DbInfo['dbpass'],
+            $this->DbInfo['dbname']
+        );
+
+        // That's not sexy but it gets the job done :D
+        $lcClassName = strtolower(get_class($this));
+        $hasDefaultPrefix = !empty($Supported[$lcClassName]['prefix']);
 
         if (isset($this->DbInfo['prefix'])) {
             $this->Ex->Prefix = $this->DbInfo['prefix'];
-        // That's not sexy but it gets the job done :D we could
-        } elseif (!empty($Supported[strtolower(get_class($this))]['prefix'])) {
-            $this->Ex->Prefix = $Supported[strtolower(get_class($this))]['prefix'];
+        } elseif ($hasDefaultPrefix) {
+            $this->Ex->Prefix = $Supported[$lcClassName]['prefix'];
         }
         $this->Ex->Destination = $this->Param('dest', 'file');
         $this->Ex->DestDb = $this->Param('destdb', null);

--- a/class.exportcontroller.php
+++ b/class.exportcontroller.php
@@ -26,13 +26,21 @@ abstract class ExportController {
      * Construct and set the controller's properties from the posted form.
      */
     public function __construct() {
+        global $Supported;
+
         $this->HandleInfoForm();
 
         $this->Ex = new ExportModel;
         $this->Ex->Controller = $this;
         $this->Ex->SetConnection($this->DbInfo['dbhost'], $this->DbInfo['dbuser'], $this->DbInfo['dbpass'],
             $this->DbInfo['dbname']);
-        $this->Ex->Prefix = $this->DbInfo['prefix'];
+
+        if (isset($this->DbInfo['prefix'])) {
+            $this->Ex->Prefix = $this->DbInfo['prefix'];
+        // That's not sexy but it gets the job done :D we could
+        } elseif (!empty($Supported[strtolower(get_class($this))]['prefix'])) {
+            $this->Ex->Prefix = $Supported[strtolower(get_class($this))]['prefix'];
+        }
         $this->Ex->Destination = $this->Param('dest', 'file');
         $this->Ex->DestDb = $this->Param('destdb', null);
         $this->Ex->TestMode = $this->Param('test', false);
@@ -116,7 +124,7 @@ abstract class ExportController {
             'dbpass' => $_POST['dbpass'],
             'dbname' => $_POST['dbname'],
             'type' => $_POST['type'],
-            'prefix' => preg_replace('/[^A-Za-z0-9_-]/', '', $_POST['prefix'])
+            'prefix' => !empty($_POST['prefix']) ? preg_replace('/[^A-Za-z0-9_-]/', '', $_POST['prefix']) : null,
         );
     }
 

--- a/packages/bbpress.php
+++ b/packages/bbpress.php
@@ -7,8 +7,8 @@
  * @package VanillaPorter
  */
 
-$Supported['bbPress'] = array('name' => 'bbPress 1', 'prefix' => 'bb_');
-$Supported['bbPress']['features'] = array(
+$Supported['bbpress'] = array('name' => 'bbPress 1', 'prefix' => 'bb_');
+$Supported['bbpress']['features'] = array(
     'Comments' => 1,
     'Discussions' => 1,
     'Users' => 1,

--- a/packages/simplepress.php
+++ b/packages/simplepress.php
@@ -7,8 +7,8 @@
  * @package VanillaPorter
  */
 
-$Supported['SimplePress'] = array('name' => 'SimplePress 1', 'prefix' => 'wp_');
-$Supported['SimplePress']['features'] = array(
+$Supported['simplepress'] = array('name' => 'SimplePress 1', 'prefix' => 'wp_');
+$Supported['simplepress']['features'] = array(
     'Comments' => 1,
     'Discussions' => 1,
     'Users' => 1,


### PR DESCRIPTION
When using the porter via command line we absolutely need to specify a prefix for some packages even if we just want to use the default prefix.
With this PR, if we do not provide any prefix, it will use the default prefix defined in the $Support variable for that particular package!