### PR TITLE
Fill ThumbPath and ThumbWidth columns in Media table.

### DIFF
--- a/functions/core-functions.php
+++ b/functions/core-functions.php
@@ -6,7 +6,7 @@
  * @param $errno
  * @param $errstr
  */
-function ErrorHandler($errno, $errstr) {
+function ErrorHandler($errno, $errstr, $errFile, $errLine) {
     $ReportingLevel = error_reporting();
 
     // If error reporting is turned off, possibly by @.  Bail out.
@@ -15,7 +15,10 @@ function ErrorHandler($errno, $errstr) {
     }
 
     if (defined(DEBUG) || ($errno != E_DEPRECATED && $errno != E_USER_DEPRECATED)) {
-        echo "Error: ({$errno}) {$errstr}\n";
+        $baseDir = realpath(__DIR__.'/../').'/';
+        $errFile = str_replace($baseDir, null, $errFile);
+
+        echo "Error in $errFile line $errLine: ($errno) $errstr\n";
         die();
     }
 }

--- a/functions/core-functions.php
+++ b/functions/core-functions.php
@@ -6,7 +6,7 @@
  * @param $errno
  * @param $errstr
  */
-function ErrorHandler($errno, $errstr, $errFile, $errLine) {
+function ErrorHandler($errno, $errstr) {
     $ReportingLevel = error_reporting();
 
     // If error reporting is turned off, possibly by @.  Bail out.
@@ -15,10 +15,7 @@ function ErrorHandler($errno, $errstr, $errFile, $errLine) {
     }
 
     if (defined(DEBUG) || ($errno != E_DEPRECATED && $errno != E_USER_DEPRECATED)) {
-        $baseDir = realpath(__DIR__.'/../').'/';
-        $errFile = str_replace($baseDir, null, $errFile);
-
-        echo "Error in $errFile line $errLine: ($errno) $errstr\n";
+        echo "Error: ({$errno}) {$errstr}\n";
         die();
     }
 }

--- a/packages/expressionengine.php
+++ b/packages/expressionengine.php
@@ -189,6 +189,8 @@ class ExpressionEngine extends ExportController {
         $Media_Map = array(
             'filename' => 'Name',
             'extension' => array('Column' => 'Type', 'Filter' => array($this, 'MimeTypeFromExtension')),
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'filesize' => 'Size',
             'member_id' => 'InsertUserID',
             'attachment_date' => array('Column' => 'DateInserted', 'Filter' => array($Ex, 'TimestampToDate')),
@@ -197,6 +199,8 @@ class ExpressionEngine extends ExportController {
         $Ex->ExportTable('Media', "
          SELECT
             concat('imported/', filename) AS Path,
+            concat('imported/', filename) as thumb_path,,
+            128 as thumb_width,
             CASE WHEN post_id > 0 THEN post_id ELSE topic_id END AS ForeignID,
             CASE WHEN post_id > 0 THEN 'comment' ELSE 'discussion' END AS ForeignTable,
             'local' AS StorageMethod,
@@ -397,6 +401,25 @@ class ExpressionEngine extends ExportController {
             JOIN z_pmgroup g
                 ON pm.title2 = g.title AND pm.userids = g.userids
             SET pm.group_id = g.group_id;");
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $Value Current value
+     * @param string $Field Current field
+     * @param array $Row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function FilterThumbnailData($Value, $Field, $Row) {
+        if (strpos(MimeTypeFromExtension($Row['extension']), 'image/') === 0) {
+            return $Value;
+        } else {
+            return null;
+        }
     }
 
 }

--- a/packages/expressionengine.php
+++ b/packages/expressionengine.php
@@ -199,7 +199,7 @@ class ExpressionEngine extends ExportController {
         $Ex->ExportTable('Media', "
          SELECT
             concat('imported/', filename) AS Path,
-            concat('imported/', filename) as thumb_path,,
+            concat('imported/', filename) as thumb_path,
             128 as thumb_width,
             CASE WHEN post_id > 0 THEN post_id ELSE topic_id END AS ForeignID,
             CASE WHEN post_id > 0 THEN 'comment' ELSE 'discussion' END AS ForeignTable,

--- a/packages/ipb.php
+++ b/packages/ipb.php
@@ -500,6 +500,8 @@ class IPB extends ExportController {
             'attach_file' => 'Name',
             'attach_path' => 'Path',
             'attach_date' => array('Column' => 'DateInserted', 'Filter' => 'TimestampToDate'),
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'attach_member_id' => 'InsertUserID',
             'attach_filesize' => 'Size',
             'ForeignID' => 'ForeignID',
@@ -511,6 +513,8 @@ class IPB extends ExportController {
         $Sql = "select
    a.*,
    concat('~cf/ipb/', a.attach_location) as attach_path,
+   concat('~cf/ipb/', a.attach_location) as thumb_path,
+   128 as thumb_width,
    ty.atype_mimetype,
    case when p.pid = t.topic_firstpost then 'discussion' else 'comment' end as ForeignTable,
    case when p.pid = t.topic_firstpost then t.tid else p.pid end as ForeignID,
@@ -820,6 +824,25 @@ drop table tmp_group;");
         if (count($Selects) > 0) {
             $Statement = implode(', ', $Selects);
             $Sql = str_replace('from ', ", $Statement\nfrom ", $Sql);
+        }
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $Value Current value
+     * @param string $Field Current field
+     * @param array $Row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function FilterThumbnailData($Value, $Field, $Row) {
+        if (strpos($Row['atype_mimetype'], 'image/') === 0) {
+            return $Value;
+        } else {
+            return null;
         }
     }
 }

--- a/packages/kunena.php
+++ b/packages/kunena.php
@@ -155,6 +155,8 @@ class Kunena extends ExportController {
             'userid' => 'InsertUserID',
             'size' => 'Size',
             'path2' => array('Column' => 'Path', 'Filter' => 'UrlDecode'),
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'filetype' => 'Type',
             'filename' => array('Column' => 'Name', 'Filter' => 'UrlDecode'),
             'time' => array('Column' => 'DateInserted', 'Filter' => 'TimestampToDate'),
@@ -171,6 +173,25 @@ class Kunena extends ExportController {
             on m.id = a.mesid", $Media_Map);
 
         $Ex->EndExport();
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $Value Current value
+     * @param string $Field Current field
+     * @param array $Row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function FilterThumbnailData($Value, $Field, $Row) {
+        if (strpos($Row['filetype'], 'image/') === 0) {
+            return $Value;
+        } else {
+            return null;
+        }
     }
 }
 

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -456,8 +456,8 @@ join z_pmgroup g
         $Media_Map = array(
             'attach_id' => 'MediaID',
             'real_filename' => 'Name',
-            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'BuildMediaPath')),
-            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'BuildMediaPath')),
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'post_id' => 'InsertUserID',
             'mimetype' => 'Type',
             'filesize' => 'Size',
@@ -574,7 +574,7 @@ join :_topics t
      * @param array $Row Contents of the current record.
      * @return current value of the field or null if the file is not an image.
      */
-    public function BuildMediaPath($Value, $Field, $Row) {
+    public function FilterThumbnailData($Value, $Field, $Row) {
         if (strpos($Row['mimetype'], 'image/') === 0) {
             return $Value;
         } else {

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -456,6 +456,8 @@ join z_pmgroup g
         $Media_Map = array(
             'attach_id' => 'MediaID',
             'real_filename' => 'Name',
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'BuildMediaPath')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'BuildMediaPath')),
             'post_id' => 'InsertUserID',
             'mimetype' => 'Type',
             'filesize' => 'Size',
@@ -465,6 +467,8 @@ join z_pmgroup g
   case when a.post_msg_id = t.topic_first_post_id then 'discussion' else 'comment' end as ForeignTable,
   case when a.post_msg_id = t.topic_first_post_id then a.topic_id else a.post_msg_id end as ForeignID,
   concat('$cdn','FileUpload/', a.physical_filename, '.', a.extension) as Path,
+  concat('$cdn','FileUpload/', a.physical_filename, '.', a.extension) as thumb_path,
+  128 as thumb_width,
   FROM_UNIXTIME(a.filetime) as DateInserted,
   'local' as StorageMethod,
   a.*
@@ -557,6 +561,25 @@ join :_topics t
             $r);
 
         return $r;
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $Value Current value
+     * @param string $Field Current field
+     * @param array $Row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function BuildMediaPath($Value, $Field, $Row) {
+        if (strpos($Row['mimetype'], 'image/') === 0) {
+            return $Value;
+        } else {
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
Some packages do not fill ThumbPath and ThumbWith for images when exporting.
This PR is fixing that!