### PR TITLE
Fill ThumbPath and ThumbWidth columns in Media table.

### DIFF
--- a/functions/filter-functions.php
+++ b/functions/filter-functions.php
@@ -428,27 +428,32 @@ function GuessFormat($Value) {
  * @return string
  */
 function MimeTypeFromExtension($Value) {
+
+    if (strpos($Value, '.') === 0) {
+        $Value = substr($Value, 1);
+    }
+
     switch ($Value) {
-        case '.png':
-        case '.jpg':
-        case '.jpeg':
-        case '.gif':
-        case '.bmp':
-            return 'image/' . substr($Value, 1);
-        case '.zip':
-        case '.doc':
-        case '.docx':
-        case '.pdf':
-        case '.xls':
-        case '.swf':
-            return 'application/' . substr($Value, 1);
-        case '.txt':
-        case '.htm':
-        case '.html':
-            return 'text/' . substr($Value, 1);
-        case '.mov':
-        case '.avi':
-            return 'video/' . substr($Value, 1);
+        case 'png':
+        case 'jpg':
+        case 'jpeg':
+        case 'gif':
+        case 'bmp':
+            return 'image/' . $Value;
+        case 'zip':
+        case 'doc':
+        case 'docx':
+        case 'pdf':
+        case 'xls':
+        case 'swf':
+            return 'application/' . $Value;
+        case 'txt':
+        case 'htm':
+        case 'html':
+            return 'text/' . $Value;
+        case 'mov':
+        case 'avi':
+            return 'video/' . $Value;
     }
 }
 

--- a/packages/expressionengine.php
+++ b/packages/expressionengine.php
@@ -415,7 +415,7 @@ class ExpressionEngine extends ExportController {
      * @return current value of the field or null if the file is not an image.
      */
     public function FilterThumbnailData($Value, $Field, $Row) {
-        if (strpos(MimeTypeFromExtension($Row['extension']), 'image/') === 0) {
+        if (strpos(MimeTypeFromExtension(strtolower($Row['extension'])), 'image/') === 0) {
             return $Value;
         } else {
             return null;

--- a/packages/expressionengine.php
+++ b/packages/expressionengine.php
@@ -189,6 +189,8 @@ class ExpressionEngine extends ExportController {
         $Media_Map = array(
             'filename' => 'Name',
             'extension' => array('Column' => 'Type', 'Filter' => array($this, 'MimeTypeFromExtension')),
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'filesize' => 'Size',
             'member_id' => 'InsertUserID',
             'attachment_date' => array('Column' => 'DateInserted', 'Filter' => array($Ex, 'TimestampToDate')),
@@ -197,6 +199,8 @@ class ExpressionEngine extends ExportController {
         $Ex->ExportTable('Media', "
          SELECT
             concat('imported/', filename) AS Path,
+            concat('imported/', filename) as thumb_path,
+            128 as thumb_width,
             CASE WHEN post_id > 0 THEN post_id ELSE topic_id END AS ForeignID,
             CASE WHEN post_id > 0 THEN 'comment' ELSE 'discussion' END AS ForeignTable,
             'local' AS StorageMethod,
@@ -397,6 +401,25 @@ class ExpressionEngine extends ExportController {
             JOIN z_pmgroup g
                 ON pm.title2 = g.title AND pm.userids = g.userids
             SET pm.group_id = g.group_id;");
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $Value Current value
+     * @param string $Field Current field
+     * @param array $Row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function FilterThumbnailData($Value, $Field, $Row) {
+        if (strpos(MimeTypeFromExtension($Row['extension']), 'image/') === 0) {
+            return $Value;
+        } else {
+            return null;
+        }
     }
 
 }

--- a/packages/expressionengine.php
+++ b/packages/expressionengine.php
@@ -188,7 +188,7 @@ class ExpressionEngine extends ExportController {
         // Media.
         $Media_Map = array(
             'filename' => 'Name',
-            'extension' => array('Column' => 'Type', 'Filter' => array($this, 'MimeTypeFromExtension')),
+            'extension' => array('Column' => 'Type', 'Filter' => 'MimeTypeFromExtension'),
             'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
             'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'filesize' => 'Size',

--- a/packages/expressionengine.php
+++ b/packages/expressionengine.php
@@ -412,7 +412,7 @@ class ExpressionEngine extends ExportController {
      * @param string $Value Current value
      * @param string $Field Current field
      * @param array $Row Contents of the current record.
-     * @return current value of the field or null if the file is not an image.
+     * @return string|null Return the supplied value if the record's file is an image. Return null otherwise
      */
     public function FilterThumbnailData($Value, $Field, $Row) {
         if (strpos(MimeTypeFromExtension(strtolower($Row['extension'])), 'image/') === 0) {

--- a/packages/ipb.php
+++ b/packages/ipb.php
@@ -836,7 +836,7 @@ drop table tmp_group;");
      * @param string $Value Current value
      * @param string $Field Current field
      * @param array $Row Contents of the current record.
-     * @return current value of the field or null if the file is not an image.
+     * @return string|null Return the supplied value if the record's file is an image. Return null otherwise
      */
     public function FilterThumbnailData($Value, $Field, $Row) {
         if (strpos(strtolower($Row['atype_mimetype']), 'image/') === 0) {

--- a/packages/ipb.php
+++ b/packages/ipb.php
@@ -500,6 +500,8 @@ class IPB extends ExportController {
             'attach_file' => 'Name',
             'attach_path' => 'Path',
             'attach_date' => array('Column' => 'DateInserted', 'Filter' => 'TimestampToDate'),
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'attach_member_id' => 'InsertUserID',
             'attach_filesize' => 'Size',
             'ForeignID' => 'ForeignID',
@@ -511,6 +513,8 @@ class IPB extends ExportController {
         $Sql = "select
    a.*,
    concat('~cf/ipb/', a.attach_location) as attach_path,
+   concat('~cf/ipb/', a.attach_location) as thumb_path,
+   128 as thumb_width,
    ty.atype_mimetype,
    case when p.pid = t.topic_firstpost then 'discussion' else 'comment' end as ForeignTable,
    case when p.pid = t.topic_firstpost then t.tid else p.pid end as ForeignID,
@@ -820,6 +824,25 @@ drop table tmp_group;");
         if (count($Selects) > 0) {
             $Statement = implode(', ', $Selects);
             $Sql = str_replace('from ', ", $Statement\nfrom ", $Sql);
+        }
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $Value Current value
+     * @param string $Field Current field
+     * @param array $Row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function FilterThumbnailData($Value, $Field, $Row) {
+        if (strpos($Row['atype_mimetype'], 'image/') === 0) {
+            return $Value;
+        } else {
+            return null;
         }
     }
 }

--- a/packages/ipb.php
+++ b/packages/ipb.php
@@ -839,7 +839,7 @@ drop table tmp_group;");
      * @return current value of the field or null if the file is not an image.
      */
     public function FilterThumbnailData($Value, $Field, $Row) {
-        if (strpos($Row['atype_mimetype'], 'image/') === 0) {
+        if (strpos(strtolower($Row['atype_mimetype']), 'image/') === 0) {
             return $Value;
         } else {
             return null;

--- a/packages/kunena.php
+++ b/packages/kunena.php
@@ -155,6 +155,8 @@ class Kunena extends ExportController {
             'userid' => 'InsertUserID',
             'size' => 'Size',
             'path2' => array('Column' => 'Path', 'Filter' => 'UrlDecode'),
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'filetype' => 'Type',
             'filename' => array('Column' => 'Name', 'Filter' => 'UrlDecode'),
             'time' => array('Column' => 'DateInserted', 'Filter' => 'TimestampToDate'),
@@ -165,12 +167,33 @@ class Kunena extends ExportController {
             concat(a.folder, '/', a.filename) as path2,
             'local' as StorageMethod,
             case when m.id = m.thread then 'discussion' else 'comment' end as ForeignTable,
-            m.time
+            m.time,
+            concat(a.folder, '/', a.filename) as thumb_path,
+            128 as thumb_width
          from :_kunena_attachments a
          join :_kunena_messages m
             on m.id = a.mesid", $Media_Map);
 
         $Ex->EndExport();
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $Value Current value
+     * @param string $Field Current field
+     * @param array $Row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function FilterThumbnailData($Value, $Field, $Row) {
+        if (strpos($Row['filetype'], 'image/') === 0) {
+            return $Value;
+        } else {
+            return null;
+        }
     }
 }
 

--- a/packages/kunena.php
+++ b/packages/kunena.php
@@ -189,7 +189,7 @@ class Kunena extends ExportController {
      * @return current value of the field or null if the file is not an image.
      */
     public function FilterThumbnailData($Value, $Field, $Row) {
-        if (strpos($Row['filetype'], 'image/') === 0) {
+        if (strpos(strtolower($Row['filetype']), 'image/') === 0) {
             return $Value;
         } else {
             return null;

--- a/packages/kunena.php
+++ b/packages/kunena.php
@@ -186,7 +186,7 @@ class Kunena extends ExportController {
      * @param string $Value Current value
      * @param string $Field Current field
      * @param array $Row Contents of the current record.
-     * @return current value of the field or null if the file is not an image.
+     * @return string|null Return the supplied value if the record's file is an image. Return null otherwise
      */
     public function FilterThumbnailData($Value, $Field, $Row) {
         if (strpos(strtolower($Row['filetype']), 'image/') === 0) {

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -456,6 +456,8 @@ join z_pmgroup g
         $Media_Map = array(
             'attach_id' => 'MediaID',
             'real_filename' => 'Name',
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'post_id' => 'InsertUserID',
             'mimetype' => 'Type',
             'filesize' => 'Size',
@@ -465,6 +467,8 @@ join z_pmgroup g
   case when a.post_msg_id = t.topic_first_post_id then 'discussion' else 'comment' end as ForeignTable,
   case when a.post_msg_id = t.topic_first_post_id then a.topic_id else a.post_msg_id end as ForeignID,
   concat('$cdn','FileUpload/', a.physical_filename, '.', a.extension) as Path,
+  concat('$cdn','FileUpload/', a.physical_filename, '.', a.extension) as thumb_path,
+  128 as thumb_width,
   FROM_UNIXTIME(a.filetime) as DateInserted,
   'local' as StorageMethod,
   a.*
@@ -557,6 +561,25 @@ join :_topics t
             $r);
 
         return $r;
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $Value Current value
+     * @param string $Field Current field
+     * @param array $Row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function FilterThumbnailData($Value, $Field, $Row) {
+        if (strpos($Row['mimetype'], 'image/') === 0) {
+            return $Value;
+        } else {
+            return null;
+        }
     }
 }
 

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -572,7 +572,7 @@ join :_topics t
      * @param string $Value Current value
      * @param string $Field Current field
      * @param array $Row Contents of the current record.
-     * @return current value of the field or null if the file is not an image.
+     * @return string|null Return the supplied value if the record's file is an image. Return null otherwise
      */
     public function FilterThumbnailData($Value, $Field, $Row) {
         if (strpos(strtolower($Row['mimetype']), 'image/') === 0) {

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -575,7 +575,7 @@ join :_topics t
      * @return current value of the field or null if the file is not an image.
      */
     public function FilterThumbnailData($Value, $Field, $Row) {
-        if (strpos($Row['mimetype'], 'image/') === 0) {
+        if (strpos(strtolower($Row['mimetype']), 'image/') === 0) {
             return $Value;
         } else {
             return null;

--- a/packages/punbb.php
+++ b/packages/punbb.php
@@ -334,7 +334,7 @@ class Punbb extends ExportController {
      * @return current value of the field or null if the file is not an image.
      */
     public function FilterThumbnailData($value, $field, $row) {
-        if (strpos($row['file_mime_type'], 'image/') === 0) {
+        if (strpos(strtolower($row['file_mime_type']), 'image/') === 0) {
             return $value;
         } else {
             return null;

--- a/packages/punbb.php
+++ b/packages/punbb.php
@@ -227,15 +227,20 @@ class Punbb extends ExportController {
                 'filename' => 'Name',
                 'file_mime_type' => 'Type',
                 'size' => 'Size',
-                'owner_id' => 'InsertUserID'
+                'owner_id' => 'InsertUserID',
+                'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+                'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             );
             $Ex->ExportTable('Media', "
-          SELECT f.*,
-             concat({$this->cdn}, 'FileUpload/', f.file_path) AS Path,
-             from_unixtime(f.uploaded_at) AS DateInserted,
-             CASE WHEN post_id IS NULL THEN 'Discussion' ELSE 'Comment' END AS ForeignTable,
-             coalesce(post_id, topic_id) AS ForieignID
-          FROM :_attach_files f", $Media_Map);
+                select f.*,
+                    concat({$this->cdn}, 'FileUpload/', f.file_path) as Path,
+                    concat({$this->cdn}, 'FileUpload/', f.file_path) as thumb_path,
+                    128 as thumb_width,
+                    from_unixtime(f.uploaded_at) as DateInserted,
+                    case when post_id is null then 'Discussion' else 'Comment' end as ForeignTable,
+                    coalesce(post_id, topic_id) as ForieignID
+                from :_attach_files f
+            ", $Media_Map);
         }
 
 
@@ -312,6 +317,25 @@ class Punbb extends ExportController {
             $AvatarBasename = basename($AvatarFilename);
 
             return "{$this->cdn}punbb/avatars/$AvatarBasename";
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $value Current value
+     * @param string $field Current field
+     * @param array $row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function FilterThumbnailData($value, $field, $row) {
+        if (strpos($row['file_mime_type'], 'image/') === 0) {
+            return $value;
         } else {
             return null;
         }

--- a/packages/punbb.php
+++ b/packages/punbb.php
@@ -331,7 +331,7 @@ class Punbb extends ExportController {
      * @param string $value Current value
      * @param string $field Current field
      * @param array $row Contents of the current record.
-     * @return current value of the field or null if the file is not an image.
+     * @return string|null Return the supplied value if the record's file is an image. Return null otherwise
      */
     public function FilterThumbnailData($value, $field, $row) {
         if (strpos(strtolower($row['file_mime_type']), 'image/') === 0) {

--- a/packages/smf.php
+++ b/packages/smf.php
@@ -399,7 +399,7 @@ join :_personal_messages pm2
 
         $extension = pathinfo($fileName, PATHINFO_EXTENSION);
         if ($extension) {
-            $mimeType = MimeTypeFromExtension('.'.$extension);
+            $mimeType = MimeTypeFromExtension('.'.strtolower($extension));
         }
 
         return $mimeType;

--- a/packages/smf.php
+++ b/packages/smf.php
@@ -176,18 +176,31 @@ class SMF extends ExportController {
             'ID_MSG' => 'ForeignID',
             'size' => 'Size',
             'height' => 'ImageHeight',
-            'width' => 'ImageWidth'
+            'width' => 'ImageWidth',
+            'extract_mimetype' => array(
+                'Column' => 'Type',
+                'Filter' => function($value, $field, $row) {
+                    return $this->getMimeTypeFromFileName($row['Path']);
+                }
+            ),
+            'thumb_path' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'FilterThumbnailData')),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
         );
-        $Ex->ExportTable('Media',
-            "select a.*,
-         concat('attachments/', a.filename) as Path,
-         concat('attachments/', b.filename) as ThumbPath,
-         if(t.ID_TOPIC is null, 'Comment', 'Discussion') as ForeignTable
-       from :_attachments a
-       left join :_attachments b on b.ID_ATTACH = a.ID_THUMB
-       left join :_topics t on a.ID_MSG = t.ID_FIRST_MSG
-       where a.attachmentType = 0
-         and a.ID_MSG > 0;", $Media_Map);
+        //
+        $Ex->ExportTable('Media', "
+            select
+                a.*,
+                concat('attachments/', a.filename) as Path,
+                IF(b.filename is not null, concat('attachments/', b.filename), null) as thumb_path,
+                null as extract_mimetype,
+                b.width as thumb_width,
+                if(t.ID_TOPIC is null, 'Comment', 'Discussion') as ForeignTable
+            from :_attachments a
+                left join :_attachments b on b.ID_ATTACH = a.ID_THUMB
+                left join :_topics t on a.ID_MSG = t.ID_FIRST_MSG
+            where a.attachmentType = 0
+                and a.ID_MSG > 0
+        ", $Media_Map);
 
         // Conversations need a bit more conversion so execute a series of queries for that.
         $Ex->Query('create table :_smfpmto (
@@ -372,6 +385,43 @@ join :_personal_messages pm2
             } else {
                 return chr(0xe0 | (0x0f & ($char >> 12))) . chr(0x80 | (0x3f & ($char >> 6))) . chr(0x80 | (0x3f & $char));
             }
+        }
+    }
+
+    /**
+     * Determine mime type from file name
+     *
+     * @param string $fileName File name (Can be full path or file name only)
+     * @return null|string Mime type if it could be determined or null.
+     */
+    public function getMimeTypeFromFileName($fileName) {
+        $mimeType = null;
+
+        $extension = pathinfo($fileName, PATHINFO_EXTENSION);
+        if ($extension) {
+            $mimeType = MimeTypeFromExtension('.'.$extension);
+        }
+
+        return $mimeType;
+    }
+
+    /**
+     * Filter used by $Media_Map to replace value for ThumbPath and ThumbWidth when the file is not an image.
+     *
+     * @access public
+     * @see ExportModel::_ExportTable
+     *
+     * @param string $value Current value
+     * @param string $field Current field
+     * @param array $row Contents of the current record.
+     * @return current value of the field or null if the file is not an image.
+     */
+    public function FilterThumbnailData($value, $field, $row) {
+        $mimeType = $this->getMimeTypeFromFileName($row['Path']);
+        if ($mimeType && strpos($mimeType, 'image/') === 0) {
+            return $value;
+        } else {
+            return null;
         }
     }
 }

--- a/packages/smf.php
+++ b/packages/smf.php
@@ -414,7 +414,7 @@ join :_personal_messages pm2
      * @param string $value Current value
      * @param string $field Current field
      * @param array $row Contents of the current record.
-     * @return current value of the field or null if the file is not an image.
+     * @return string|null Return the supplied value if the record's file is an image. Return null otherwise
      */
     public function FilterThumbnailData($value, $field, $row) {
         $mimeType = $this->getMimeTypeFromFileName($row['Path']);

--- a/packages/smf2.php
+++ b/packages/smf2.php
@@ -304,7 +304,7 @@ class SMF2 extends ExportController {
 
         $extension = pathinfo($fileName, PATHINFO_EXTENSION);
         if ($extension) {
-            $mimeType = MimeTypeFromExtension('.'.$extension);
+            $mimeType = MimeTypeFromExtension('.'.strtolower($extension));
         }
 
         return $mimeType;

--- a/packages/smf2.php
+++ b/packages/smf2.php
@@ -319,7 +319,7 @@ class SMF2 extends ExportController {
      * @param string $value Current value
      * @param string $field Current field
      * @param array $row Contents of the current record.
-     * @return current value of the field or null if the file is not an image.
+     * @return string|null Return the supplied value if the record's file is an image. Return null otherwise
      */
     public function FilterThumbnailData($value, $field, $row) {
         $mimeType = $this->getMimeTypeFromFileName($row['Path']);

--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -1263,7 +1263,7 @@ class Vbulletin extends ExportController {
      * @param string $value Current value
      * @param string $field Current field
      * @param array $row Contents of the current record.
-     * @return current value of the field or null if the file is not an image.
+     * @return string|null Return the supplied value if the record's file is an image. Return null otherwise
      */
     public function FilterThumbnailData($value, $field, $row) {
         if (strpos(MimeTypeFromExtension(strtolower($row['extension'])), 'image/') === 0) {

--- a/packages/vbulletin5.php
+++ b/packages/vbulletin5.php
@@ -492,13 +492,26 @@ class Vbulletin5 extends Vbulletin {
         /// Drafts
         // autosavetext table
 
+        $instance = $this;
         // Media
         $Media_Map = array(
             'nodeid' => 'MediaID',
             'filename' => 'Name',
             'extension' => array('Column' => 'Type', 'Filter' => array($this, 'BuildMimeType')),
             'Path2' => array('Column' => 'Path', 'Filter' => array($this, 'BuildMediaPath')),
-            'ThumbPath2' => array('Column' => 'ThumbPath', 'Filter' => array($this, 'BuildMediaPath')),
+            'ThumbPath2' => array(
+                'Column' => 'ThumbPath',
+                'Filter' => function($Value, $Field, $Row) use ($instance) {
+                    $filteredData = $this->FilterThumbnailData($Value, $Field, $Row);
+
+                    if ($filteredData) {
+                        return $instance->BuildMediaPath($Value, $Field, $Row);
+                    } else {
+                        return null;
+                    }
+                }
+            ),
+            'thumb_width' => array('Column' => 'ThumbWidth', 'Filter' => array($this, 'FilterThumbnailData')),
             'width' => 'ImageWidth',
             'height' => 'ImageHeight',
             'filesize' => 'Size',
@@ -508,6 +521,7 @@ class Vbulletin5 extends Vbulletin {
                 a.*,
                 filename as Path2,
                 filename as ThumbPath2,
+                128 as thumb_width,
                 FROM_UNIXTIME(f.dateline) as DateInserted,
                 f.userid as userid,
                 f.userid as InsertUserID,


### PR DESCRIPTION
Some packages do not fill ThumbPath and ThumbWith for images when exporting.
This PR is fixing that!