### PR TITLE
Add missing php closing tag because make.php needs them.

### DIFF
--- a/packages/bbpress2.php
+++ b/packages/bbpress2.php
@@ -211,3 +211,6 @@ class BbPress2 extends ExportController {
         $Ex->EndExport();
     }
 }
+
+?>
+


### PR DESCRIPTION
Fix an exception to the coding standard... we need those closing php tags at the end of the packages!
When refactoring the code we should make it clear that they are mandatory.
See https://github.com/vanilla/porter/commit/144c5b6b9d3ab0fde76c77fc5840bec8f67ecc3d

