### PR TITLE
Fix code logic about default packages

### DIFF
--- a/class.exportcontroller.php
+++ b/class.exportcontroller.php
@@ -39,19 +39,22 @@ abstract class ExportController {
             $this->dbInfo['dbname']
         );
 
+        $this->ex->prefix = '';
+
         // That's not sexy but it gets the job done :D
         $lcClassName = strtolower(get_class($this));
-        $hasDefaultPrefix = !empty($supported[$lcClassName]['prefix']);
+        $hasDefaultPrefix = array_key_exists('prefix', $supported[$lcClassName]);
 
         if (isset($this->dbInfo['prefix'])) {
-            if ($this->dbInfo['prefix'] === 'PACKAGE_DEFAULT' && $hasDefaultPrefix) {
-                $this->ex->prefix = $supported[$lcClassName]['prefix'];
+            if ($this->dbInfo['prefix'] === 'PACKAGE_DEFAULT') {
+                if ($hasDefaultPrefix) {
+                    $this->ex->prefix = $supported[$lcClassName]['prefix'];
+                }
             } else {
                 $this->ex->prefix = $this->dbInfo['prefix'];
             }
-        } else {
-            $this->ex->prefix = '';
         }
+
         $this->ex->destination = $this->param('dest', 'file');
         $this->ex->destDb = $this->param('destdb', null);
         $this->ex->testMode = $this->param('test', false);

--- a/class.exportcontroller.php
+++ b/class.exportcontroller.php
@@ -43,7 +43,7 @@ abstract class ExportController {
 
         // That's not sexy but it gets the job done :D
         $lcClassName = strtolower(get_class($this));
-        $hasDefaultPrefix = array_key_exists('prefix', $supported[$lcClassName]);
+        $hasDefaultPrefix = !empty($supported[$lcClassName]['prefix']);
 
         if (isset($this->dbInfo['prefix'])) {
             if ($this->dbInfo['prefix'] === 'PACKAGE_DEFAULT') {


### PR DESCRIPTION
There was a problem with the old logic that put DEFAULT_PACKAGE as the prefix for a package with no prefix defined.