### PR TITLE
Fix index detection in vbulletin package.

### DIFF
--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -940,8 +940,8 @@ class VBulletin extends ExportController {
         if ($ex->exists('attachment', array('contenttypeid', 'contentid')) === true) {
             // Exporting 4.x with 'filedata' table.
             // Build an index to join on.
-            $result = $ex->query('show index from :_thread where Key_name = "ix_thread_firstpostid"');
-            if (!$result) {
+            $result = $ex->query('show index from :_thread where Key_name = "ix_thread_firstpostid"', true);
+            if (!mysql_num_rows($result)) {
                 $ex->query('create index ix_thread_firstpostid on :_thread (firstpostid)');
             }
             $mediaSql = "


### PR DESCRIPTION
It is not fun when an index is missing...

It can be the difference between this:
![screen shot 2016-05-11 at 6 29 28 pm](https://cloud.githubusercontent.com/assets/2412909/15198607/65af735e-17a6-11e6-8a6e-6a9552d3f425.png)

and that:
![screen shot 2016-05-11 at 6 31 18 pm](https://cloud.githubusercontent.com/assets/2412909/15198635/965d3e00-17a6-11e6-9bd3-9f06da8b2adf.png)

The first run do 76910 X 2159741 comparisons. Takes hours ?!?

The second run do 76910 comparisons. Takes 6.44 seconds.