### PR TITLE
Remove in package [vbulletin] discussions and comments DateUpdated field

### DIFF
--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -529,7 +529,6 @@ class VBulletin extends ExportController {
                 convert(ABS(open-1), char(1)) as Closed,
                 if(convert(sticky, char(1)) > 0, 2, 0) as Announce,
                 from_unixtime(t.dateline) as DateInserted,
-                from_unixtime(lastpost) as DateUpdated,
                 from_unixtime(lastpost) as DateLastComment,
                 if (t.pollid > 0, 'Poll', null) as Type
             from :_thread as t
@@ -556,8 +555,7 @@ class VBulletin extends ExportController {
                 'BBCode' as Format,
                 p.userid as InsertUserID,
                 p.userid as UpdateUserID,
-                from_unixtime(p.dateline) as DateInserted,
-                from_unixtime(p.dateline) as DateUpdated
+                from_unixtime(p.dateline) as DateInserted
             from :_post as p
                 inner join :_thread as t on p.threadid = t.threadid
                 left join :_deletionlog as d on (d.type='post' and d.primaryid=p.postid)


### PR DESCRIPTION
Remove discussions and comments DateUpdated field in  package vbulletin (3 & 4). Field was displaying the same information as DateInserted. Which makes the DateUpdated field obsolete.  