### PR TITLE
Fix --help detection

### DIFF
--- a/functions/commandline-functions.php
+++ b/functions/commandline-functions.php
@@ -166,7 +166,7 @@ function parseCommandLine($options = null, $files = null) {
 
     $opts = getOptFromArgv($shortCodes, $longCodes);
 
-    if (isset($opts['help']) || isset($opts['h'])) {
+    if (array_key_exists($opts['help']) || array_key_exists($opts['h'])) {
         writeCommandLineHelp();
         die();
     }


### PR DESCRIPTION
The --help command-line argument was broken, because isset doesn't like NULL values.