### PR TITLE
Include both 'stickied' and 'announced' discussion options 

### DIFF
--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -255,7 +255,7 @@ class PhpBB3 extends ExportController {
             select t.*,
                 'BBCode' as Format,
                 case t.topic_status when 1 then 1 else 0 end as Closed,
-                case t.topic_type when 1 then 1 else 0 end as Announce,
+                case t.topic_type when 1 then 1 when 2 then 2 else 0 end as Announce,
                 case when t.poll_start > 0 then 'poll' else null end as type,
                 FROM_UNIXTIME(t.topic_time) as DateInserted,
                 FROM_UNIXTIME(t.topic_last_post_time) as DateUpdated,

--- a/packages/phpbb3.php
+++ b/packages/phpbb3.php
@@ -255,7 +255,7 @@ class PhpBB3 extends ExportController {
             select t.*,
                 'BBCode' as Format,
                 case t.topic_status when 1 then 1 else 0 end as Closed,
-                case t.topic_type when 1 then 1 when 2 then 2 else 0 end as Announce,
+                case t.topic_type when 1 then 2 when 2 then 2 else 0 end as Announce,
                 case when t.poll_start > 0 then 'poll' else null end as type,
                 FROM_UNIXTIME(t.topic_time) as DateInserted,
                 FROM_UNIXTIME(t.topic_last_post_time) as DateUpdated,


### PR DESCRIPTION
Include both 'stickied' and 'announced' discussion options as "Announce" in the export of the discussion table of the phpbb3 package.

Migrating topic_type 2 as a type 2 announcement in Vanilla to not over populate the recent discussions sections.