### PR TITLE
Command line help showed wrong shortcut for selective table export

### DIFF
--- a/functions/commandline-functions.php
+++ b/functions/commandline-functions.php
@@ -88,7 +88,7 @@ $globalOptions = array(
     'tables' => array(
         'Selective export, limited to specified tables, if provided',
         'Sx' => ':',
-        'Short' => 's',
+        'Short' => 't',
     )
 );
 


### PR DESCRIPTION
Command line help was displaying "-s" instead of "-t" for selective table export