### PR TITLE
Fix vbulletin package handling of BBcode ATTACH tag

### DIFF
--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -501,6 +501,10 @@ class VBulletin extends ExportController {
         // Discussions
         $discussion_Map = array(
             'title' => array('Column' => 'Name', 'Filter' => 'HTMLDecoder'),
+            'pagetext' => array('Column' => 'Body', 'Filter' => function ($value) {
+                    return preg_replace('~\[ATTACH=CONFIG\]\d+\[\/ATTACH\]~i', '', $value);
+                }
+            ),
         );
 
         if ($ex->destination == 'database') {
@@ -523,7 +527,7 @@ class VBulletin extends ExportController {
                 t.title,
                 p.postid as ForeignID,
                 p.ipaddress as InsertIPAddress,
-                p.pagetext as Body,
+                p.pagetext,
                 'BBCode' as Format,
                 replycount+1 as CountComments,
                 convert(ABS(open-1), char(1)) as Closed,
@@ -541,7 +545,12 @@ class VBulletin extends ExportController {
         ", $discussion_Map);
 
         // Comments
-        $comment_Map = array();
+        $comment_Map = array(
+            'pagetext' => array('Column' => 'Body', 'Filter' => function ($value) {
+                    return preg_replace('~\[ATTACH=CONFIG\]\d+\[\/ATTACH\]~i', '', $value);
+                }
+            ),
+        );
         if ($minDiscussionID) {
             $minDiscussionWhere = "and p.threadid > $minDiscussionID";
         }
@@ -550,7 +559,7 @@ class VBulletin extends ExportController {
             select
                 p.postid as CommentID,
                 p.threadid as DiscussionID,
-                p.pagetext as Body,
+                p.pagetext,
                 p.ipaddress as InsertIPAddress,
                 'BBCode' as Format,
                 p.userid as InsertUserID,


### PR DESCRIPTION
Some vBulletin discussions and/or comments include BBCode [ATTACH] tags.

For example:

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

[ATTACH=CONFIG]71[/ATTACH]
```

Result is this after migration on Vanilla:

<img width="829" alt="screen shot 2018-02-05 at 4 57 08 pm" src="https://user-images.githubusercontent.com/15312192/35830898-cf1743d8-0a95-11e8-9757-71a9b6789b64.png">

We are correctly migrating the attachment to the media table but displaying the [ATTACH] tag creates a "duplicate" of the same attachment as a link to the same file. More precisely:

```
<a rel="nofollow" href="{domain}/uploads/attachments/25/52.jpg">bar.jpg</a>
``` 

Since the file is already there as an attachment and the "faulty" displaying of the [ATTACH] tag removing the tag from the body is the solution this PR implements.
