### PR TITLE
Fix imagecreatefromjpeg throwing fatal errors during blobs export

### DIFF
--- a/functions/core-functions.php
+++ b/functions/core-functions.php
@@ -129,9 +129,8 @@ function generateThumbnail($path, $thumbPath, $height = 50, $width = 50) {
                 break;
             case 2:
                 $sourceImage = @imagecreatefromjpeg($path);
-                if (!$sourceImage)
-                {
-                    $sourceImage= imagecreatefromstring(file_get_contents($path));
+                if (!$sourceImage) {
+                    $sourceImage = imagecreatefromstring(file_get_contents($path));
                 }
                 break;
             case 3:

--- a/functions/core-functions.php
+++ b/functions/core-functions.php
@@ -128,7 +128,11 @@ function generateThumbnail($path, $thumbPath, $height = 50, $width = 50) {
                 $sourceImage = imagecreatefromgif($path);
                 break;
             case 2:
-                $sourceImage = imagecreatefromjpeg($path);
+                $sourceImage = @imagecreatefromjpeg($path);
+                if (!$sourceImage)
+                {
+                    $sourceImage= imagecreatefromstring(file_get_contents($path));
+                }
                 break;
             case 3:
                 $sourceImage = imagecreatefrompng($path);


### PR DESCRIPTION
When images are corrupted/too old GD crashes, which makes PHP crash.

Ignoring the first error and creating thumbnail from string when imagecreatefromjpeg doesn't work.

Closes https://github.com/vanilla/porter/issues/136