### PR TITLE
Add a table exists function to the export model

### DIFF
--- a/class.exportmodel.php
+++ b/class.exportmodel.php
@@ -1233,6 +1233,18 @@ class ExportModel {
         return $result->nextResultRow() !== false;
     }
 
+    /**
+     * Determine if a table exists
+     *
+     * @param $tableName
+     * @return bool
+     */
+    public function tableExists($tableName) {
+        $result = $this->query("show tables like '$tableName'");
+
+        return !empty($result->nextResultRow());
+    }
+
 }
 
 ?>

--- a/packages/class.hmdglobal.php
+++ b/packages/class.hmdglobal.php
@@ -1,0 +1,1 @@
+../../hmd-global/packages/class.hmdglobal.php

--- a/packages/class.hmdglobal.php
+++ b/packages/class.hmdglobal.php
@@ -1,1 +1,0 @@
-../../hmd-global/packages/class.hmdglobal.php


### PR DESCRIPTION
In some migrations, i.e. when temp tables are needed, it is useful to know if a table exists.

I added a generic function to query that information to the export model.