### PR TITLE
Fix undefined variable in get function of export model

### DIFF
--- a/class.exportmodel.php
+++ b/class.exportmodel.php
@@ -529,6 +529,7 @@ class ExportModel {
      */
     public function get($sql, $indexColumn = false) {
         $r = $this->_query($sql);
+        $result = [];
 
         while ($row = ($r->nextResultRow())) {
             if ($indexColumn) {


### PR DESCRIPTION
An undefined variable error will occur if the query result of the get function in the export model is empty.

```
Error in class.exportmodel.php line 541: (8) Undefined variable: result
```

This fix simply declares the $result variable and set it to an empty array by default.