### PR TITLE
Porter was Stripping [ATTACH] BBCode form posts

### DIFF
--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -502,7 +502,7 @@ class VBulletin extends ExportController {
         $discussion_Map = array(
             'title' => array('Column' => 'Name', 'Filter' => 'HTMLDecoder'),
             'pagetext' => array('Column' => 'Body', 'Filter' => function ($value) {
-                    return preg_replace('~\[ATTACH=CONFIG\]\d+\[\/ATTACH\]~i', '', $value);
+                    return $value;
                 }
             ),
         );
@@ -547,7 +547,7 @@ class VBulletin extends ExportController {
         // Comments
         $comment_Map = array(
             'pagetext' => array('Column' => 'Body', 'Filter' => function ($value) {
-                    return preg_replace('~\[ATTACH=CONFIG\]\d+\[\/ATTACH\]~i', '', $value);
+                    return $value;
                 }
             ),
         );


### PR DESCRIPTION
This will leave BBCode in Comments and Discussions as Vanilla is able to handle these tags. I am not sure why they were being stripped out as this strips out all inline images