### PR TITLE
Add MVC Porter package.

### DIFF
--- a/class.exportmodel.php
+++ b/class.exportmodel.php
@@ -1255,11 +1255,16 @@ class ExportModel {
      */
     public function columnExists($tableName, $columnName){
 
-        $result=$this->query("select *
-                                    from INFORMATION_SCHEMA.COLUMNS
-                                    where TABLE_SCHEMA = DATABASE()
-                                    and table_name = '$tableName'
-                                    and column_name = '$columnName'");
+        $result=$this->query("
+            select 
+                column_name
+            from 
+                information_schema.columns
+            where 
+                table_schema = database()
+                and table_name = '$tableName'
+                and column_name = '$columnName'
+        ");
         return $result->nextResultRow() !== false;
     }
 

--- a/class.exportmodel.php
+++ b/class.exportmodel.php
@@ -1246,6 +1246,23 @@ class ExportModel {
         return !empty($result->nextResultRow());
     }
 
+    /**
+     * Determine if a column exists in a table
+     *
+     * @param $tableName
+     * @param $columnName
+     * @return bool
+     */
+    public function columnExists($tableName, $columnName){
+
+        $result=$this->query("select *
+                                    from INFORMATION_SCHEMA.COLUMNS
+                                    where TABLE_SCHEMA = DATABASE()
+                                    and table_name = '$tableName'
+                                    and column_name = '$columnName'");
+        return $result->nextResultRow() !== false;
+    }
+
 }
 
 ?>

--- a/packages/mvc.php
+++ b/packages/mvc.php
@@ -327,11 +327,11 @@ class MVC extends ExportController {
                 u.Filename as Name,
                 concat('attachments/', u.Filename) as Path,
                 '' as Type,
-                '' as Size,
+                0 as Size,
                 MembershipUser_Id InsertUserID,
                 u.DateCreated as DateInserted
             from UploadedFile u, MediaId m
-            where m.Id = u.Id
+            where u.Post_Id <> '' and m.Id = u.Id
         ", $attachment_Map);
 
         $ex->endExport();

--- a/packages/mvc.php
+++ b/packages/mvc.php
@@ -17,7 +17,7 @@ $supported['mvc']['features'] = array(
     'Categories' => 1,
     'Roles' => 1,
     'Avatars' => 1,
-    'Attachments' => 1,
+    'Attachments' => 0,
     'Signatures' => 1,
     'Tags' => 1,
 );
@@ -95,7 +95,7 @@ class MVC extends ExportController {
 
         if(!$ex->tableExists("UserId")){
             $ex->query("create table UserId as (
-                    select Id from :_MembershipUser)
+                    select Id from MembershipUser)
             ");
 
             $ex->query("ALTER TABLE UserId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
@@ -143,7 +143,7 @@ class MVC extends ExportController {
 
         if(!$ex->tableExists("RoleId")){
             $ex->query("create table RoleId as (
-                    select Id from :_MembershipRole)
+                    select Id from MembershipRole)
             ");
 
             $ex->query("ALTER TABLE RoleId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
@@ -172,7 +172,7 @@ class MVC extends ExportController {
 
         if(!$ex->tableExists("BadgeId")){
             $ex->query("create table BadgeId as (
-                    select Id from :_Badge)
+                    select Id from Badge)
             ");
 
             $ex->query("ALTER TABLE BadgeId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
@@ -201,7 +201,6 @@ class MVC extends ExportController {
             where u.Id = m.MembershipUser_Id and b.Id = m.Badge_Id
         ", $user_badge_Map);
 
-        // TODO Assign default parent category
         // Category.
         $category_Map = array();
 
@@ -259,7 +258,7 @@ class MVC extends ExportController {
                 m.CreateDate as DateInserted,
                 m.Name as Name,
                 m.Views as CountViews,
-                'BBCode' as Format
+                'Html' as Format
             from Topic m, DiscussionId d, CategoryId c, UserId u
             where d.Id = m.Id and c.Id = m.Category_Id and u.Id = m.MembershipUser_Id
 
@@ -270,7 +269,7 @@ class MVC extends ExportController {
 
         if(!$ex->tableExists("CommentId")){
             $ex->query("create table CommentId as (
-                    select Id from :_Post)
+                    select Id from Post)
             ");
 
             $ex->query("ALTER TABLE CommentId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
@@ -284,7 +283,7 @@ class MVC extends ExportController {
                 m.PostContent as Body,
                 m.DateCreated as DateInserted,
                 m.DateEdited as DateUpdated,
-                'BBCode' as Format
+                'Html' as Format
             from Post m, CommentId c, DiscussionId d, UserId u
             where c.Id = m.Id and d.Id = m.Topic_Id and u.Id = m.MembershipUser_Id
          ", $comment_Map);
@@ -294,7 +293,7 @@ class MVC extends ExportController {
 
         if(!$ex->tableExists("TagId")){
             $ex->query("create table TagId as (
-                    select Id from :_TopicTag)
+                    select Id from TopicTag)
             ");
 
             $ex->query("ALTER TABLE TagId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
@@ -311,16 +310,18 @@ class MVC extends ExportController {
          ", $tag_Map);
 
         //Attachment WIP
+        /*
         $attachment_Map = array();
 
         if(!$ex->tableExists("MediaId")){
             $ex->query("create table MediaId as (
-                    select Id from :_UploadedFile)
+                    select Id from UploadedFile)
             ");
 
             $ex->query("ALTER TABLE MediaId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
         }
 
+        // Use of placeholder for Type and Size due to lack of data in db. Will require external script to get the info.
         $ex->exportTable('Attachment', "
             select
                 m.VanillaID  as MediaID,
@@ -333,7 +334,7 @@ class MVC extends ExportController {
             from UploadedFile u, MediaId m
             where u.Post_Id <> '' and m.Id = u.Id
         ", $attachment_Map);
-
+        */
         $ex->endExport();
     }
 }

--- a/packages/mvc.php
+++ b/packages/mvc.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * MVC exporter tool.
+ *
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GNU GPL2
+ * @package VanillaPorter
+ * @see functions.commandline.php for command line usage.
+ */
+
+$supported['mvc'] = array('name' => 'mvc', 'prefix' => 'mvc_');
+$supported['mvc']['features'] = array(
+    'Comments' => 1,
+    'Discussions' => 1,
+    'Users' => 1,
+    'Badge,' => 1,
+    'Categories' => 1,
+    'Roles' => 1,
+);
+
+class MVC extends ExportController {
+    /**
+     * You can use this to require certain tables and columns be present.
+     *
+     * @var array Required tables => columns
+     */
+    protected $sourceTables = array(
+        'MembershipUser' => array(),
+    );
+
+    /**
+     * Main export process.
+     *
+     * @param ExportModel $ex
+     * @see $_Structures in ExportModel for allowed destination tables & columns.
+     */
+    public function forumExport($ex) {
+
+        $characterSet = $ex->getCharacterSet('posts');
+        if ($characterSet) {
+            $ex->characterSet = $characterSet;
+        }
+
+        // Reiterate the platform name here to be included in the porter file header.
+        $ex->beginExport('', 'MVC');
+
+        // TODO Convert ID and map them
+
+        // User.
+        $user_Map = array();
+        $ex->exportTable('User', "
+            select
+                u.Id as UserID,
+                u.UserName as Name,
+                'Reset' as HashMethod,
+                u.Email as Email,
+                u.Avatar as Photo,
+                u.CreateDate as DateInserted,
+                u.LastLoginDate as DateLastVisit,
+                u.LastActivityDate as DateLastActive,
+                u.IsBanned as Banned,
+                u.Location as Location
+            from :_MembershipUser as u
+         ", $user_Map);
+
+        // Role.
+        $role_Map = array();
+        $ex->exportTable('Role', "
+            select
+                r.Id as RoleID,
+                r.RoleName as Name
+            from :_MembershipRole as r
+         ", $role_Map);
+
+        // User Role.
+        $userRole_Map = array();
+        $ex->exportTable('UserRole', "
+            select
+                u.UserIdentifier as UserID,
+                u.RoleIdentifier as RoleID
+            from :_MembershipUsersInRoles as u
+        ", $userRole_Map);
+
+        //Badge
+        $Badge_Map = array();
+        $ex->exportTable('Badge', "
+            select
+                b.Id as BadgeID,
+                b.Type as Type,
+                b.DisplayName as Name,
+                b.Description as Descripton,
+                b.Image as Photo,
+                b.AwardsPoints as Points
+            from :_Badge as b
+        ", $Badge_Map);
+
+        // TODO Assign default parent category
+        // Category.
+        $category_Map = array();
+        $ex->exportTable('Category', "
+            select
+                f.Id as CategoryID,
+                f.Category_Id as ParentCategoryID,
+                f.Name as Name,
+                f.Description as Description,
+                f.DateCreated as DateInserted,
+                null as Sort
+            from :_Category as f
+        ", $category_Map);
+
+        // TODO : handle FAWMechPost and FAQMechTopic
+        // Discussion.
+        $discussion_Map = array();
+        $ex->exportTable('Discussion', "
+            select
+                t.Id as DiscussionID,
+                t.Category_id as CategoryID,
+                t.MembershipUser_id as InsertUserID,
+                t.CreateDate as DateInserted,
+                t.Name as Name,
+                t.Views as CountViews,
+                'BBCode' as Format
+            from :_Topic as t
+            ", $discussion_Map);
+
+        // Comment.
+        $comment_Map = array();
+        $ex->exportTable('Comment', "
+            select
+                p.Id as CommentID,
+                p.Topic_id as DiscussionID,
+                p.MembershipUser_id as InsertUserID,
+                p.PostContent as Body,
+                p.DateCreated as DateInserted,
+                p.DateEdited as DateUpdated,
+                'BBCode' as Format
+            from :_Post as p
+         ", $comment_Map);
+
+        // Global permissions
+
+        $ex->endExport();
+    }
+
+    private function idConverter(){
+        // TODO
+    }
+}
+
+// Closing PHP tag required. (make.php)
+?>

--- a/packages/mvc.php
+++ b/packages/mvc.php
@@ -16,6 +16,10 @@ $supported['mvc']['features'] = array(
     'Badge,' => 1,
     'Categories' => 1,
     'Roles' => 1,
+    'Avatars' => 1,
+    'Attachments' => 1,
+    'Signatures' => 1,
+    'Tags' => 1,
 );
 
 class MVC extends ExportController {
@@ -34,7 +38,8 @@ class MVC extends ExportController {
      * @param ExportModel $ex
      * @see $_Structures in ExportModel for allowed destination tables & columns.
      */
-    public function forumExport($ex) {
+    public function forumExport($ex)
+    {
 
         $characterSet = $ex->getCharacterSet('posts');
         if ($characterSet) {
@@ -44,106 +49,292 @@ class MVC extends ExportController {
         // Reiterate the platform name here to be included in the porter file header.
         $ex->beginExport('', 'MVC');
 
-        // TODO Convert ID and map them
+        $structures = $ex->structures();
+        $structures['Badge'] = array(
+            'BadgeID' => 'int',
+            'Name' => 'varchar(64)',
+            'Slug' => 'varchar(32)',
+            'Type' => 'varchar(20)',
+            'Body' => 'Text',
+            'Photo' => 'varchar(255)',
+            'Points' => 'int',
+            'Active' => 'tinyint',
+            'Visible' => 'tinyint',
+            'Secret' => 'tinyint',
+            'CanDelete' => 'tinyint',
+            'DateInserted' => 'datetime',
+            'DateUpdated' => 'datetime',
+            'InsertUserID' => 'int',
+            'UpdateUser' => 'int',
+            'CountRecipients' => 'int',
+            'Threshold' => 'int',
+            'Class' => 'varchar(20)',
+            'Level' => 'smallint',
+            'Attributes' => 'text'
+        );
 
-        // User.
+        $structures['UserBadge'] = array(
+            'UserID' => 'int',
+            'BadgeID' => 'int',
+            'Attributes' => 'text',
+            'Reason' => 'varchar(255)',
+            'ShowReason' => 'tinyint',
+            'DateRequested' => 'datetime',
+            'RequestReason' => 'varchar(255)',
+            'Declined' => 'tinyint',
+            'Count' => 'int',
+            "DateCompleted" => 'datetime',
+            'DateInserted' => 'datetime',
+            'InsertUserID' => 'int'
+        );
+
+        $ex->structures($structures);
+
+        // Users.
         $user_Map = array();
+
+        if(!$ex->tableExists("UserId")){
+            $ex->query("create table UserId as (
+                    select Id from :_MembershipUser)
+            ");
+
+            $ex->query("ALTER TABLE UserId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
+        }
+
         $ex->exportTable('User', "
             select
-                u.Id as UserID,
-                u.UserName as Name,
+                u.VanillaID as UserId,
+                m.UserName as Name,
                 'Reset' as HashMethod,
-                u.Email as Email,
-                u.Avatar as Photo,
-                u.CreateDate as DateInserted,
-                u.LastLoginDate as DateLastVisit,
-                u.LastActivityDate as DateLastActive,
-                u.IsBanned as Banned,
-                u.Location as Location
-            from :_MembershipUser as u
+                m.Email as Email,
+                m.Avatar as Photo,
+                m.CreateDate as DateInserted,
+                m.LastLoginDate as DateLastVisit,
+                m.LastActivityDate as DateLastActive,
+                m.IsBanned as Banned,
+                m.Location as Location
+            from MembershipUser m, UserId u
+
+            where u.Id = m.Id
          ", $user_Map);
+
+        // UserMeta.
+        $ex->exportTable('UserMeta', "
+            select
+                u.VanillaID as UserID,
+                'Website' as `Name`,
+                m.Website as `Value`
+            from MembershipUser m, UserId u
+            where m.Website <> '' and u.Id = m.Id
+
+            union
+
+            select
+                u.VanillaID as UserID,
+                'Signatures.Sig',
+                m.Signature
+            from MembershipUser m, UserId u
+            where m.Signature <> '' and u.Id = m.Id
+
+        ");
 
         // Role.
         $role_Map = array();
+
+        if(!$ex->tableExists("RoleId")){
+            $ex->query("create table RoleId as (
+                    select Id from :_MembershipRole)
+            ");
+
+            $ex->query("ALTER TABLE RoleId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
+        }
+
         $ex->exportTable('Role', "
             select
-                r.Id as RoleID,
-                r.RoleName as Name
-            from :_MembershipRole as r
+                r.VanillaID as RoleID,
+                m.RoleName as Name
+            from MembershipRole m, RoleId r
+            where r.Id = m.Id
          ", $role_Map);
 
         // User Role.
         $userRole_Map = array();
         $ex->exportTable('UserRole', "
             select
-                u.UserIdentifier as UserID,
-                u.RoleIdentifier as RoleID
-            from :_MembershipUsersInRoles as u
+                u.VanillaID as UserID,
+                r.VanillaID as RoleID
+            from MembershipUsersInRoles m, RoleId r, UserId u
+            where r.Id = m.RoleIdentifier and u.Id = m.UserIdentifier
         ", $userRole_Map);
 
-        //Badge
-        $Badge_Map = array();
+        //Badge.
+        $badge_Map = array();
+
+        if(!$ex->tableExists("BadgeId")){
+            $ex->query("create table BadgeId as (
+                    select Id from :_Badge)
+            ");
+
+            $ex->query("ALTER TABLE BadgeId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
+        }
+
         $ex->exportTable('Badge', "
             select
-                b.Id as BadgeID,
-                b.Type as Type,
-                b.DisplayName as Name,
-                b.Description as Descripton,
-                b.Image as Photo,
-                b.AwardsPoints as Points
-            from :_Badge as b
-        ", $Badge_Map);
+                b.VanillaID as BadgeID,
+                m.Type as Type,
+                m.DisplayName as Name,
+                m.Description as Body,
+                m.Image as Photo,
+                m.AwardsPoints as Points
+            from Badge m, BadgeId b
+            where b.Id = m.Id
+        ", $badge_Map);
+
+        $user_badge_Map = array();
+        $ex->exportTable('UserBadge', "
+            select
+                u.VanillaID as UserID,
+                b.VanillaID as BadgeID,
+                '' as Status,
+                now() as DateInserted
+            from MembershipUser_Badge m, UserId u, BadgeId b
+            where u.Id = m.MembershipUser_Id and b.Id = m.Badge_Id
+        ", $user_badge_Map);
 
         // TODO Assign default parent category
         // Category.
         $category_Map = array();
+
+        if(!$ex->tableExists("CategoryId")){
+            $ex->query("create table CategoryId as (
+                    select Id from :_Category)
+            ");
+
+            $ex->query("ALTER TABLE CategoryId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
+        }
+
         $ex->exportTable('Category', "
-            select
-                f.Id as CategoryID,
-                f.Category_Id as ParentCategoryID,
-                f.Name as Name,
-                f.Description as Description,
-                f.DateCreated as DateInserted,
+
+                          select
+                c.VanillaID as CategoryID,
+                p.VanillaID as ParentCategoryID,
+                m.Name as Name,
+                m.Description as Description,
+                m.DateCreated as DateInserted,
                 null as Sort
-            from :_Category as f
+            from Category m, CategoryId c, CategoryId p
+            where m.Category_Id <> '' and c.Id = m.Id and p.Id = m.Category_Id
+
+            UNION
+
+            select
+                c.VanillaID as CategoryID,
+                '-1' as ParentCategoryID,
+                m.Name as Name,
+                m.Description as Description,
+                m.DateCreated as DateInserted,
+                null as Sort
+            from Category m, CategoryId c
+            where m.Category_Id = '' and c.Id = m.Id
+
+
         ", $category_Map);
 
-        // TODO : handle FAWMechPost and FAQMechTopic
         // Discussion.
         $discussion_Map = array();
+
+        if(!$ex->tableExists("DiscussionId")){
+            $ex->query("create table DiscussionId as (
+                    select Id from :_Topic)
+            ");
+
+            $ex->query("ALTER TABLE DiscussionId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
+        }
+
         $ex->exportTable('Discussion', "
             select
-                t.Id as DiscussionID,
-                t.Category_id as CategoryID,
-                t.MembershipUser_id as InsertUserID,
-                t.CreateDate as DateInserted,
-                t.Name as Name,
-                t.Views as CountViews,
+                d.VanillaID as DiscussionID,
+                c.VanillaID as CategoryID,
+                u.VanillaID as InsertUserID,
+                m.CreateDate as DateInserted,
+                m.Name as Name,
+                m.Views as CountViews,
                 'BBCode' as Format
-            from :_Topic as t
+            from Topic m, DiscussionId d, CategoryId c, UserId u
+            where d.Id = m.Id and c.Id = m.Category_Id and u.Id = m.MembershipUser_Id
+
             ", $discussion_Map);
 
         // Comment.
         $comment_Map = array();
+
+        if(!$ex->tableExists("CommentId")){
+            $ex->query("create table CommentId as (
+                    select Id from :_Post)
+            ");
+
+            $ex->query("ALTER TABLE CommentId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
+        }
+
         $ex->exportTable('Comment', "
             select
-                p.Id as CommentID,
-                p.Topic_id as DiscussionID,
-                p.MembershipUser_id as InsertUserID,
-                p.PostContent as Body,
-                p.DateCreated as DateInserted,
-                p.DateEdited as DateUpdated,
+                c.VanillaID as CommentID,
+                d.VanillaID as DiscussionID,
+                u.VanillaID as InsertUserID,
+                m.PostContent as Body,
+                m.DateCreated as DateInserted,
+                m.DateEdited as DateUpdated,
                 'BBCode' as Format
-            from :_Post as p
+            from Post m, CommentId c, DiscussionId d, UserId u
+            where c.Id = m.Id and d.Id = m.Topic_Id and u.Id = m.MembershipUser_Id
          ", $comment_Map);
 
-        // Global permissions
+        // Tag
+        $tag_Map = array();
+
+        if(!$ex->tableExists("TagId")){
+            $ex->query("create table TagId as (
+                    select Id from :_TopicTag)
+            ");
+
+            $ex->query("ALTER TABLE TagId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
+        }
+
+        $ex->exportTable('Tag', "
+            select
+                t.VanillaID as TagID,
+                m.Tag as Name,
+                m.Tag as FullName,
+                now() as DateInserted
+            from TopicTag m, TagId t
+            where t.Id = m.Id
+         ", $tag_Map);
+
+        //Attachment WIP
+        $attachment_Map = array();
+
+        if(!$ex->tableExists("MediaId")){
+            $ex->query("create table MediaId as (
+                    select Id from :_UploadedFile)
+            ");
+
+            $ex->query("ALTER TABLE MediaId ADD VanillaID INT NOT NULL AUTO_INCREMENT PRIMARY KEY");
+        }
+
+        $ex->exportTable('Attachment', "
+            select
+                m.VanillaID  as MediaID,
+                u.Filename as Name,
+                concat('attachments/', u.Filename) as Path,
+                '' as Type,
+                '' as Size,
+                MembershipUser_Id InsertUserID,
+                u.DateCreated as DateInserted
+            from UploadedFile u, MediaId m
+            where m.Id = u.Id
+        ", $attachment_Map);
 
         $ex->endExport();
-    }
-
-    private function idConverter(){
-        // TODO
     }
 }
 


### PR DESCRIPTION
# Changes
* Added porter for MVC forums

# Features
* Comments
* Discussions
* Users
* Badge 
* Categories
* Roles
* Avatars
* Signatures
* Tags

# Incomplete feature
* Attachments

# Notes
* Extracted features are limited to the one mention in : [Ansys estimate](https://github.com/vanillaforums/estimates/blob/master/ansys/migration.estimate.md).
* Attachments have no size or type in the original db, will require an additional script to set properly. Said script can't be done as of this PR since the attachments files were not available. Writing this script is estimated at **one (1) hours**.
* The porter is slow when it come to features with a large number rows or multiple ID's like comments or discussions. This is due to the fact that all ID's have to be converted from GUID to integer using translation table to ensure the db integrity.
* The ID's conversion only affect the ID's of the export, the ID's of the origin db are left as is preserve the original data.