### PR TITLE
Create PDO connection with utf8mb4 charset

### DIFF
--- a/database/class.pdodb.php
+++ b/database/class.pdodb.php
@@ -22,7 +22,7 @@ class PdoDB implements DbResource {
             die('PDO extension not found. See config.php and make sure the necessary extensions are installed.');
         }
         try {
-            $this->link = new PDO('mysql:host='.$args['dbhost'].';dbname='.$args['dbname'], $args['dbuser'], $args['dbpass']);
+            $this->link = new PDO('mysql:host='.$args['dbhost'].';dbname='.$args['dbname'].';charset=utf8mb4', $args['dbuser'], $args['dbpass']);
             $this->link->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
         } catch (Throwable $t) {
             // Executed only in PHP 7, will not match in PHP 5


### PR DESCRIPTION
This seems to be required for indic characters and emoji too:
See https://open.vanillaforums.com/discussion/comment/262376/#Comment_262376

It's also how Vanilla creates a PDO connection:
https://github.com/vanilla/vanilla/blob/aee14ffe5d8edd899fe25c50ddb4cb9bae1169c3/library/database/class.database.php#L334