### PR TITLE
Fix syntax error in errorHandler

### DIFF
--- a/functions/core-functions.php
+++ b/functions/core-functions.php
@@ -19,7 +19,7 @@ function errorHandler($errno, $errstr, $errFile, $errLine) {
         return;
     }
 
-    if (defined(DEBUG) || ($errno != E_DEPRECATED && $errno != E_USER_DEPRECATED)) {
+    if (defined('DEBUG') || ($errno != E_DEPRECATED && $errno != E_USER_DEPRECATED)) {
         $baseDir = realpath(__DIR__.'/../').'/';
         $errFile = str_replace($baseDir, null, $errFile);
 


### PR DESCRIPTION
The function `defined()` takes a string. This was calling the value of the constant itself, which generally does not exist.