### PR TITLE
Remove `die` from vBulletin package

### DIFF
--- a/packages/vbulletin.php
+++ b/packages/vbulletin.php
@@ -335,7 +335,6 @@ class VBulletin extends ExportController {
         }
         # Export from our tmp table and drop
         $this->ex->exportTable('UserRole', 'select distinct userid, usergroupid from VbulletinRoles', $userRole_Map);
-        die();
         $this->ex->query("drop table if exists VbulletinRoles");
 
         // Permissions.


### PR DESCRIPTION
Seems suspicious.

Introduced in https://github.com/vanilla/porter/pull/208 