### PR TITLE
fix xenforo password

### DIFF
--- a/packages/xenforo.php
+++ b/packages/xenforo.php
@@ -259,7 +259,7 @@ class Xenforo extends ExportController {
          select
             u.*,
             ua.data as password,
-            'xenforo' as hash_method,
+            if(length(data) > 100, 'Reset', 'xenforo'),
             case when u.avatar_date > 0 then concat('{$cdn}xf/', u.user_id div 1000, '/', u.user_id, '.jpg') else null end as avatar
          from :_user u
          left join :_user_authenticate ua


### PR DESCRIPTION
# Issue

Xenforo password can be absurdly long going over the 100 char limit supported by Vanilla.

# Solution 

Implement a check that will set the password to Reset if the length is longer than 100 chars.