### PR TITLE
added alias table and fix typo in drupal porter

### DIFF
--- a/functions/structure-functions.php
+++ b/functions/structure-functions.php
@@ -442,6 +442,12 @@ function vanillaStructure() {
             'CssClass' => 'varchar(20)',
             'Sort' => 'int'
         ),
+        'pageRouteAlias' => array(
+            'pageRouteAliasID' => 'int',
+            'recordID' => 'int',
+            'recordType' => 'varchar(32)',
+            'alias' => 'varchar(255)'
+        ),
         'Permission' => array(
             'PermissionID' => 'int',
             'RoleID' => 'int',
@@ -776,7 +782,7 @@ function vanillaStructure() {
             'Attributes' => 'text'
         ),
         'UserPoints' => array(
-            'SlotType' => 'varchar(1)',
+            'SlotType' => array('d','w','m','y','a'),
             'TimeSlot' => 'datetime',
             'Source' => 'varchar(10)',
             'CategoryID' => 'int',

--- a/packages/drupal7.php
+++ b/packages/drupal7.php
@@ -156,7 +156,7 @@ class Drupal7 extends ExportController {
             left join :_field_data_body b on b.entity_id = n.nid
             left join :_forum f on f.vid = n.vid
             left join :_field_revision_body r on r.revision_id = n.vid
-            left join ( select i.nid, concat('\n<img src=\"{$this->path}', replace(uri, 'public://', ''), ' alt=\"', fileName, '\">') as image
+            left join ( select i.nid, concat('\n<img src=\"{$this->path}', replace(uri, 'public://', ''), '\" alt=\"', fileName, '\">') as image
                         from :_image i
                         join :_file_managed fm on fm.fid = i.fid
                         where image_size not like '%thumbnail') i on i.nid = n.nid


### PR DESCRIPTION
# Changes
* Added Alias table for KB redirects.
* Fix typo in Drupal 7 porter that was breaking embedded images.